### PR TITLE
Add audit-log notifier: login alerts + activity digest

### DIFF
--- a/docs/browser-test-cases-notifier.md
+++ b/docs/browser-test-cases-notifier.md
@@ -1,0 +1,325 @@
+# Browser/behavioral test cases — Audit-log Notifier (Claude-in-Chrome)
+
+Test plan for `feature/audit-log-notifier`: the **Notifications** card on the
+Others settings tab, the **per-event login alerts** (async email), and the
+scheduled **activity digest** (daily / weekly / monthly). Written so the UI cases
+can be driven by the Claude-in-Chrome browser tools; the email/cron cases are
+verified with `wp-cli` + a mail catcher.
+
+Companion to [`browser-test-cases.md`](browser-test-cases.md) (Redirects + Rules)
+and [`browser-test-cases-subpages.md`](browser-test-cases-subpages.md) (admin
+subpages). Implements the acceptance list in
+[`notifier-plan.md`](notifier-plan.md) §8.
+
+## Environment & setup
+
+- **Settings URL:** `https://woocommerce.test/wp-admin/admin.php?page=wplalr_login_logout_redirect`
+  → click the **Others** tab (hash `#/others`).
+- **Auth:** logged in as an admin (`manage_options`).
+- **Gating:** the Notifier hooks nothing unless logging is enabled
+  (`wplalr_enable_logs === 'yes'`). Turn logging **on** before any alert/digest case.
+- **Mail capture:** these tests assert that `wp_mail()` is *invoked* with the
+  right recipient/subject. Use one of:
+  - **MailHog** on the Herd site (preferred): read the captured message in its UI
+    / API (`http://localhost:8025`).
+  - A **`wp_mail` interceptor** (no SMTP needed) — see
+    [Mail interceptor snippet](#mail-interceptor-snippet).
+
+### State helpers (run in the project dir via shell)
+
+```bash
+# Prereq: logging on
+wp option update wplalr_enable_logs yes
+
+# Notifier options (also settable from the UI; these are for setup/inspection)
+wp option get wplalr_logs_notify_roles --format=json     # e.g. ["administrator"]
+wp option get wplalr_logs_notification_email
+wp option get wplalr_logs_digest                          # '' | daily | weekly | monthly
+
+# Cron inspection
+wp cron event list | grep wplalr            # cleanup, digest, single-event alerts
+wp cron schedule list | grep monthly        # custom 'monthly' schedule present?
+
+# Run a due event immediately
+wp cron event run wplalr_logs_digest_send
+wp cron event run wplalr_send_login_alert
+```
+
+### Pass criteria for every case
+
+- No uncaught errors in `read_console_messages` (ignore the benign
+  `InvalidStateError: Transition was aborted...` view-transition artifact).
+- No PHP critical-error snackbar.
+- Logging in/out for a real alert test must still complete normally — the alert
+  send is deferred to a single cron event, so login latency is unaffected.
+
+---
+
+## Notifications card (UI)
+
+## TC-N01 — Notifications card renders below Audit Logging
+
+**Steps**
+1. `navigate` to the settings URL, click **Others**. Screenshot.
+
+**Expected**
+- A second card titled **Notifications** appears under the Audit Logging card.
+- Controls: **Alert on login for roles** (token field), **Notification email**
+  (email text field), **Digest summary** (select: Off / Daily / Weekly / Monthly).
+- Help text notes both features require logging enabled.
+
+## TC-N02 — Notification email defaults to admin email
+
+**Steps**
+1. Pre-state: `wp option delete wplalr_logs_notification_email`.
+2. Reload the Others tab.
+
+**Expected**
+- The **Notification email** field is pre-filled with the site admin email
+  (the REST GET resolves the default from `admin_email`).
+
+## TC-N03 — Save notify roles (token field)
+
+**Steps**
+1. Click **Alert on login for roles**, type `Admin`, pick **Administrator**.
+2. Click **Save Changes**. Screenshot promptly.
+
+**Expected**
+- Role renders as a token chip "Administrator ×".
+- "Settings saved successfully!" snackbar.
+- `wp option get wplalr_logs_notify_roles --format=json` → `["administrator"]`
+  (stored as the **slug**, not the display name).
+
+## TC-N04 — Save notification email + digest cadence
+
+**Steps**
+1. Set **Notification email** = `alerts@woocommerce.test`.
+2. Set **Digest summary** = **Weekly**. Save.
+
+**Expected**
+- `wp option get wplalr_logs_notification_email` → `alerts@woocommerce.test`.
+- `wp option get wplalr_logs_digest` → `weekly`.
+
+## TC-N05 — Round-trip on reload
+
+**Steps**
+1. After TC-N03/04, full `navigate` reload of the Others tab.
+
+**Expected**
+- Role token, email, and digest select all re-render from the saved values
+  (slug→name mapping on load for the role token).
+
+## TC-N06 — Invalid email falls back to admin email (server-side)
+
+**Steps**
+1. In **Notification email** type `not-an-email`; Save.
+
+**Expected**
+- The server sanitizer rejects it and stores the site `admin_email` instead;
+  on reload the field shows the admin email, not `not-an-email`. No fatal.
+
+## TC-N07 — Empty roles disables alerts
+
+**Steps**
+1. Remove all role tokens from **Alert on login for roles**; Save.
+
+**Expected**
+- `wp option get wplalr_logs_notify_roles --format=json` → `[]`. With empty roles
+  no alert is ever queued (see TC-N10).
+
+---
+
+## Per-event login alerts (behavioral)
+
+> Set up the mail catcher first ([snippet](#mail-interceptor-snippet) or MailHog).
+
+## TC-N08 — Watched role login queues + sends one alert
+
+**Setup:** logging on; `wplalr_logs_notify_roles = ["administrator"]`;
+notification email set.
+
+**Steps**
+1. Trigger a login for an administrator. Either a real login in a separate
+   profile, or seed the recorded-event path:
+   `wp eval 'do_action( "wp_login", "admin", get_user_by( "id", 1 ) );'`
+2. Confirm a single event is scheduled:
+   `wp cron event list | grep wplalr_send_login_alert` (should show one).
+3. Run it: `wp cron event run wplalr_send_login_alert`.
+4. Check the mail catcher.
+
+**Expected**
+- Exactly **one** `wplalr_send_login_alert` single-event was queued for the login.
+- After it runs, one HTML email to the configured recipient with subject
+  `[<site>] Login alert: <user> signed in`, body containing the username, time, IP,
+  and browser/OS from the re-read log row.
+
+## TC-N09 — Login is not blocked on send (async)
+
+**Steps**
+1. With an SMTP delay or a slow `wp_mail` filter, perform a real admin login.
+
+**Expected**
+- The login + redirect complete immediately; the email send happens later when the
+  single cron event fires (not inline on `wp_login`).
+
+## TC-N10 — Non-matching role → no email
+
+**Setup:** `wplalr_logs_notify_roles = ["administrator"]`.
+
+**Steps**
+1. Log in as a **subscriber** (or
+   `wp eval 'do_action( "wp_login", "sub", get_user_by( "id", 4 ) );'`).
+
+**Expected**
+- No `wplalr_send_login_alert` event is queued; no email is sent.
+
+## TC-N11 — Empty roles → no email
+
+**Setup:** `wplalr_logs_notify_roles = []`.
+
+**Steps**
+1. Log in as an administrator.
+
+**Expected**
+- No alert queued, regardless of role.
+
+## TC-N12 — Logging off → Notifier inert
+
+**Setup:** `wp option update wplalr_enable_logs no`.
+
+**Steps**
+1. Log in as an administrator (with notify roles configured).
+
+**Expected**
+- No row recorded, no alert queued, no email (the Notifier returns early when
+  logging is off, same guard as the Logger).
+
+---
+
+## Digest (cron)
+
+## TC-N13 — Custom `monthly` schedule registered
+
+**Steps**
+1. `wp cron schedule list`.
+
+**Expected**
+- A `monthly` schedule (~30 days) appears alongside core
+  hourly/twicedaily/daily/weekly.
+
+## TC-N14 — Setting a cadence schedules the event
+
+**Steps**
+1. In the UI set **Digest summary** = **Daily**, Save (or
+   `wp option update wplalr_logs_digest daily`).
+2. `wp cron event list | grep wplalr_logs_digest_send`.
+
+**Expected**
+- `wplalr_logs_digest_send` is scheduled with the `daily` recurrence
+  (next run ~1 hour out).
+
+## TC-N15 — Changing cadence reschedules
+
+**Steps**
+1. Change **Digest summary** Daily → **Weekly**, Save.
+2. Re-list the cron event.
+
+**Expected**
+- The old daily occurrence is cleared and a single `weekly` occurrence exists
+  (no duplicate digest events).
+
+## TC-N16 — Setting Off clears the event
+
+**Steps**
+1. Set **Digest summary** = **Off**, Save.
+2. `wp cron event list | grep wplalr_logs_digest_send`.
+
+**Expected**
+- No `wplalr_logs_digest_send` event remains scheduled.
+
+## TC-N17 — Digest email contents
+
+**Setup:** logging on; seed a known mix of events in the window, e.g.
+`wp eval 'do_action("wp_login","admin",get_user_by("id",1)); do_action("wp_login_failed","x", new WP_Error());'`
+cadence = `daily`; mail catcher ready.
+
+**Steps**
+1. `wp cron event run wplalr_logs_digest_send` (or `do_action('wplalr_logs_digest_send')` via `wp eval`).
+2. Check the mail catcher.
+
+**Expected**
+- One HTML email to the recipient, subject `[<site>] Daily login activity digest`,
+  body listing Successful logins / Logouts / Failed logins / Total events with
+  counts matching `LogRepository::stats()` over the cadence window.
+
+## TC-N18 — Digest no-ops when cadence empty
+
+**Steps**
+1. `wp option update wplalr_logs_digest ''`.
+2. `wp eval 'do_action("wplalr_logs_digest_send");'`.
+
+**Expected**
+- No email sent (the handler returns early when cadence is `''`).
+
+## TC-N19 — Deactivate clears all cron
+
+**Steps**
+1. With a digest cadence set, deactivate the plugin:
+   `wp plugin deactivate wp-login-and-logout-redirect`.
+2. `wp cron event list | grep wplalr`.
+
+**Expected**
+- Both `wplalr_logs_cleanup` and `wplalr_logs_digest_send` are gone
+  (`unschedule_all()` on deactivate). Reactivate to restore.
+
+---
+
+## Extensibility
+
+## TC-N20 — Email payload filters re-template
+
+**Steps**
+1. Add a small mu-plugin / snippet hooking `wplalr_log_notification_email` (alert)
+   and `wplalr_log_digest_email` (digest) to change the subject and/or `to`.
+2. Re-run TC-N08 and TC-N17.
+
+**Expected**
+- The sent email reflects the filtered subject/recipient; returning an empty `to`
+  from the filter cancels that send (no email).
+
+---
+
+## Mail interceptor snippet
+
+Drop into a mu-plugin (or run via `wp eval-file`) to capture mail without SMTP. It
+records the last message to an option you can read back with `wp option get`.
+
+```php
+add_filter( 'pre_wp_mail', function ( $null, $atts ) {
+    update_option( 'wplalr_test_last_mail', array(
+        'to'      => $atts['to'],
+        'subject' => $atts['subject'],
+        'body'    => $atts['message'],
+        'headers' => $atts['headers'],
+    ), false );
+    return true; // short-circuit actual send
+}, 10, 2 );
+```
+
+```bash
+# After triggering an alert/digest:
+wp option get wplalr_test_last_mail --format=json
+wp option delete wplalr_test_last_mail   # reset between cases
+```
+
+---
+
+## Regression checklist (run before merge)
+
+- [ ] `composer phpcs` → 0 errors / 0 warnings.
+- [ ] `php -l` clean on `includes/Logs/Notifier.php` + the edited files.
+- [ ] `npm run lint:js` (the OthersSettings card) and `npm run build` clean.
+- [ ] TC-N01 … TC-N07 pass (Notifications card UI) with no console errors.
+- [ ] TC-N08 … TC-N12 pass (alerts: matching/non-matching/empty/off).
+- [ ] TC-N13 … TC-N19 pass (digest schedule/reschedule/clear/contents/deactivate).
+- [ ] TC-N20 passes (payload filters).

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -40,6 +40,17 @@ A custom match type generally needs three hooks together: `wplalr_rule_match_typ
 (register it), `wplalr_sanitize_condition_values` (validate input), and
 `wplalr_match_condition` (evaluate it at runtime).
 
+### Notifications (`Logs\Notifier`)
+
+| Hook | Type | Signature | Purpose |
+|------|------|-----------|---------|
+| `wplalr_log_notification_email` | filter | `( array $email, array $context )` | Re-template the per-login alert email. `$email` is `[ 'to', 'subject', 'body', 'headers' ]`; `$context` is `[ 'row', 'user' ]`. |
+| `wplalr_log_digest_email` | filter | `( array $email, array $context )` | Re-template the activity digest email. `$context` is `[ 'cadence', 'stats' ]`. |
+
+Returning an empty `to` from either filter cancels that send. The digest runs on
+the `wplalr_logs_digest_send` cron event; alerts dispatch via the single-event
+`wplalr_send_login_alert` hook so login is never blocked on SMTP.
+
 ## JavaScript filters (`@wordpress/hooks`)
 
 Registered with `wp.hooks.addFilter( name, namespace, callback )`. The admin

--- a/docs/notifier-plan.md
+++ b/docs/notifier-plan.md
@@ -1,0 +1,194 @@
+# Audit-Log Notifier — Implementation Plan
+
+**Status:** Spec / planning (no code yet). Depends on Phase 1
+([`audit-logs-plan.md`](audit-logs-plan.md)), which is merged. Hangs entirely off
+the existing `wplalr_log_recorded` action that `includes/Logs/Logger.php` already
+fires (`$row_id, $data`) and the cron pattern already in
+`includes/Logs/Installer.php` — **no changes to the write path.**
+
+This is the remaining piece of the audit-logs plan's §4.3a (Notifier) and §6
+(digest cron), split out as a standalone follow-up.
+
+---
+
+## 1. Scope & decisions
+
+Two independent, both-Free features sharing one class:
+
+1. **Per-event alerts** — email an admin when a user whose role is in
+   `wplalr_logs_notify_roles` logs in successfully. Off by default (empty roles).
+2. **Digest** — a scheduled roll-up email (daily / weekly / monthly) of login
+   activity. Off by default (`''`).
+
+**Decisions (recommended defaults):**
+
+- **Trigger event for alerts:** successful `login` only (not logout / failed /
+  forced_logout in v1). Keeps it a "someone privileged just signed in" alert.
+- **Send alerts async** — `wp_schedule_single_event( time(),
+  'wplalr_send_login_alert', [ $row_id ] )` rather than calling `wp_mail()`
+  inside the `wp_login` → `wplalr_log_recorded` path. Logging in should not block
+  on SMTP. *(This is the one deviation from the original plan's "send inline";
+  cheap, and avoids login latency.)*
+- **Recipient:** `wplalr_logs_notification_email`, default resolved from
+  `{admin_email}`.
+- **Gating:** the Notifier only hooks anything when logging is enabled
+  (`wplalr_enable_logs === 'yes'`) — same guard as `Logger`. If logging is off
+  there are no rows and nothing to notify on.
+- **`monthly` is not a core cron schedule** (core has
+  hourly/twicedaily/daily/weekly). Register it via `cron_schedules`.
+
+---
+
+## 2. New options (folded into `/settings`, like the existing log options)
+
+| Option | Default | Purpose |
+|---|---|---|
+| `wplalr_logs_notification_email` | `get_option('admin_email')` | Where alerts + digests go |
+| `wplalr_logs_notify_roles` | `[]` | Roles whose login triggers an alert (`[]` = off) |
+| `wplalr_logs_digest` | `''` | `''` \| `daily` \| `weekly` \| `monthly` digest cadence |
+
+---
+
+## 3. PHP — `includes/Logs/Notifier.php` (new)
+
+Wired into the container in `WpLoginLogoutRedirect::init_classes()` after
+`logger`. Constructor returns early unless `wplalr_enable_logs === 'yes'`.
+
+**Per-event alerts:**
+
+- `add_action( 'wplalr_log_recorded', 'maybe_queue_login_alert', 10, 2 )` — when
+  `event === 'login'` and `wplalr_logs_notify_roles` is non-empty, intersect the
+  user's roles (looked up from `$data['user_id']` — `$data` carries no roles, so
+  `get_userdata()`) with the configured roles; if matched,
+  `wp_schedule_single_event` the async sender with `$row_id`.
+- `add_action( 'wplalr_send_login_alert', 'send_login_alert', 10, 1 )` — re-reads
+  the row via `LogRepository::get( $id )` (see §6), builds + sends the email.
+
+**Digest:**
+
+- `add_action( 'wplalr_logs_digest_send', 'send_digest' )` — builds a roll-up
+  from `LogRepository::stats()` + `query()` over the cadence window and emails
+  it. No-op if `wplalr_logs_digest === ''`.
+
+**Email building** (both `wp_mail`, HTML via a small template method):
+
+- Subject/body filterable: `wplalr_log_notification_email` (alert) and
+  `wplalr_log_digest_email` (digest) — `apply_filters` on
+  `[ 'to', 'subject', 'body', 'headers' ]` so Pro/users can re-template.
+
+---
+
+## 4. Cron — extend `includes/Logs/Installer.php`
+
+The cleanup cron pattern is already there; mirror it for the digest.
+
+- **Register `monthly`** via `add_filter( 'cron_schedules', … )` (≈30 days).
+- **Digest event** `wplalr_logs_digest_send`. It is **rescheduled whenever
+  `wplalr_logs_digest` changes**, not on a fixed cadence:
+  - `add_action( 'update_option_wplalr_logs_digest', 'reschedule_digest', 10, 2 )`
+    (+ `add_option_wplalr_logs_digest`) → clear the existing event, and if the new
+    value is non-empty, `wp_schedule_event( next_run, $cadence,
+    'wplalr_logs_digest_send' )`.
+  - `unschedule_cleanup()` grows into `unschedule_all()` (or add
+    `unschedule_digest()`), called from `WpLoginLogoutRedirect::deactivate()`.
+- The per-event alert uses single-events, so it needs no recurring registration.
+
+---
+
+## 5. REST + settings — `includes/REST/SettingsController.php`
+
+- `get_settings()` — add the three options (resolve email default to
+  `admin_email`; cast roles to array).
+- `update_settings()` — sanitize: `sanitize_email` (fallback to admin_email if
+  invalid/empty), roles `array_values( array_intersect( sanitize_key'd, valid
+  roles ) )`, digest `in_array( $v, [ '', 'daily', 'weekly', 'monthly' ], true )`.
+- Add the three fields to `get_item_schema()`.
+
+---
+
+## 6. `includes/Logs/LogRepository.php` — one addition
+
+- `get( int $id ): ?array` — single-row fetch (the async alert sender needs to
+  re-read the row by id; `query()` is list-only). Prepared statement, returns the
+  `prepare_item()` shape or null.
+
+---
+
+## 7. React — extend the **Others** tab (`src/components/OthersSettings.js`)
+
+Add a second card, **"Notifications"**, below the Audit Logging card (same
+`SettingsContext` save path, one round-trip):
+
+- **Notify on login (roles)** — multi-select from `window.wplalrAdmin.roles`
+  (`FormTokenField` or a checklist) → `wplalr_logs_notify_roles`.
+- **Notification email** — `TextControl type="email"` →
+  `wplalr_logs_notification_email`.
+- **Digest summary** — `SelectControl` (Off / Daily / Weekly / Monthly) →
+  `wplalr_logs_digest`.
+
+No new view, hook, or bundle — purely additive to the existing tab. Help text
+notes both require logging enabled.
+
+---
+
+## 8. Testing / acceptance
+
+- `composer phpcs` + `php -l`; `npm run build` + `npm run lint:js` clean.
+- Configure a notify role → log in as that role → assert one queued alert email
+  (capture with a `wp_mail` test interceptor or MailHog on the Herd site).
+- Non-matching role → no email. Empty roles → no email.
+- Set digest `daily` → assert `wp_next_scheduled('wplalr_logs_digest_send')` is
+  set; change to `''` → assert cleared; change cadence → assert rescheduled.
+- `monthly` appears in `wp_get_schedules()`.
+- Logging off → Notifier hooks nothing.
+- Manually run `do_action('wplalr_logs_digest_send')` → digest email with correct
+  counts from `stats()`.
+
+---
+
+## 9. File checklist
+
+**New PHP**
+- `includes/Logs/Notifier.php`
+
+**Changed PHP**
+- `includes/Logs/Installer.php` — `monthly` schedule, digest (re)scheduling on
+  option change, unschedule on deactivate.
+- `includes/Logs/LogRepository.php` — `get( $id )`.
+- `includes/REST/SettingsController.php` — three options in get/update/schema.
+- `includes/WpLoginLogoutRedirect.php` — container: `new Logs\Notifier(...)`.
+
+**Changed React**
+- `src/components/OthersSettings.js` — Notifications card.
+
+**Docs**
+- `readme.txt` — feature + privacy note that emails contain login metadata.
+- `docs/extensibility.md` — `wplalr_log_notification_email`,
+  `wplalr_log_digest_email`.
+
+---
+
+## 10. Build order
+
+1. Options + `SettingsController` fold + `LogRepository::get()` — no behavior yet.
+2. `Notifier` per-event alerts (async single-event) + container wiring.
+3. Digest: `monthly` schedule + option-change (re)scheduling + `send_digest`.
+4. Others-tab Notifications card.
+5. Email templates + filters + docs.
+
+---
+
+## 11. Open questions (recommended defaults)
+
+- Async vs. inline alert send? → **Async single-event** (avoid login latency).
+- Alert on events beyond login (failed / forced_logout)? → **Login only in v1**;
+  widen later via the same role gate.
+- Throttle alerts (many logins of a watched role)? → **No throttle v1**;
+  document, revisit if noisy.
+- HTML vs. plain-text email? → **HTML with a plain-text fallback header**,
+  filterable.
+
+---
+
+Scope: ~1 new class + 1 new React card + small edits to 4 existing files; no
+migrations, no new endpoints, no new bundle.

--- a/includes/Logs/Installer.php
+++ b/includes/Logs/Installer.php
@@ -33,12 +33,43 @@ class Installer {
 	const CLEANUP_HOOK = 'wplalr_logs_cleanup';
 
 	/**
+	 * Recurring digest cron hook.
+	 *
+	 * @var string
+	 */
+	const DIGEST_HOOK = 'wplalr_logs_digest_send';
+
+	/**
 	 * The constructor.
 	 */
 	public function __construct() {
 		// Migrate on upgrades that don't re-run the activation hook.
 		add_action( 'admin_init', array( $this, 'maybe_install' ) );
 		add_action( self::CLEANUP_HOOK, array( $this, 'run_cleanup' ) );
+
+		// `monthly` is not a core schedule; register it for the digest.
+		add_filter( 'cron_schedules', array( $this, 'register_schedules' ) );
+
+		// (Re)schedule the digest whenever its cadence option changes.
+		add_action( 'add_option_wplalr_logs_digest', array( $this, 'reschedule_digest_on_add' ), 10, 2 );
+		add_action( 'update_option_wplalr_logs_digest', array( $this, 'reschedule_digest' ), 10, 2 );
+	}
+
+	/**
+	 * Register the non-core `monthly` cron schedule.
+	 *
+	 * @param array $schedules Existing schedules.
+	 * @return array
+	 */
+	public function register_schedules( $schedules ) {
+		if ( ! isset( $schedules['monthly'] ) ) {
+			$schedules['monthly'] = array(
+				'interval' => 30 * DAY_IN_SECONDS,
+				'display'  => __( 'Once Monthly', 'wp-login-logout-redirect' ),
+			);
+		}
+
+		return $schedules;
 	}
 
 	/**
@@ -120,15 +151,59 @@ class Installer {
 	}
 
 	/**
-	 * Clear the cleanup event. Called on deactivation.
+	 * Clear all scheduled events. Called on deactivation.
+	 *
+	 * @return void
+	 */
+	public static function unschedule_all() {
+		self::clear_event( self::CLEANUP_HOOK );
+		self::clear_event( self::DIGEST_HOOK );
+	}
+
+	/**
+	 * Clear the cleanup event. Retained for back-compat.
 	 *
 	 * @return void
 	 */
 	public static function unschedule_cleanup() {
-		$timestamp = wp_next_scheduled( self::CLEANUP_HOOK );
+		self::clear_event( self::CLEANUP_HOOK );
+	}
 
-		if ( $timestamp ) {
-			wp_unschedule_event( $timestamp, self::CLEANUP_HOOK );
+	/**
+	 * Unschedule every occurrence of a hook.
+	 *
+	 * @param string $hook Cron hook name.
+	 * @return void
+	 */
+	protected static function clear_event( $hook ) {
+		wp_clear_scheduled_hook( $hook );
+	}
+
+	/**
+	 * Schedule the digest the first time the option is added.
+	 *
+	 * @param string $option Option name (unused).
+	 * @param mixed  $value  The new cadence value.
+	 * @return void
+	 */
+	public function reschedule_digest_on_add( $option, $value ) {
+		$this->reschedule_digest( '', $value );
+	}
+
+	/**
+	 * Clear and (re)schedule the digest event for the given cadence.
+	 *
+	 * @param mixed $old_value Previous cadence (unused).
+	 * @param mixed $new_value New cadence: '' | daily | weekly | monthly.
+	 * @return void
+	 */
+	public function reschedule_digest( $old_value, $new_value ) {
+		self::clear_event( self::DIGEST_HOOK );
+
+		$cadence = is_string( $new_value ) ? $new_value : '';
+
+		if ( in_array( $cadence, array( 'daily', 'weekly', 'monthly' ), true ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, $cadence, self::DIGEST_HOOK );
 		}
 	}
 

--- a/includes/Logs/LogRepository.php
+++ b/includes/Logs/LogRepository.php
@@ -62,6 +62,31 @@ class LogRepository {
 	}
 
 	/**
+	 * Fetch a single row by id.
+	 *
+	 * The async alert sender re-reads the row this way (`query()` is list-only).
+	 *
+	 * @param int $id Row id.
+	 * @return array|null The prepared row, or null when not found.
+	 */
+	public function get( $id ) {
+		global $wpdb;
+
+		$id = absint( $id );
+
+		if ( $id < 1 ) {
+			return null;
+		}
+
+		$table = Installer::table_name();
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$row = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$table} WHERE id = %d", $id ), ARRAY_A );
+
+		return $row ? $this->prepare_item( $row ) : null;
+	}
+
+	/**
 	 * Paginated, filtered query of log rows.
 	 *
 	 * @param array $args page|per_page|event|status|search|orderby|order.

--- a/includes/Logs/Notifier.php
+++ b/includes/Logs/Notifier.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\Logs;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sends audit-log email notifications.
+ *
+ * Two independent features sharing one class, both off by default:
+ *
+ * 1. Per-event alerts — emails the configured recipient when a user whose role
+ *    is in `wplalr_logs_notify_roles` logs in successfully. The send is
+ *    deferred to a single cron event so logging in never blocks on SMTP.
+ * 2. Digest — a scheduled roll-up of login activity (daily/weekly/monthly),
+ *    driven by the `wplalr_logs_digest_send` cron event registered in Installer.
+ *
+ * Hangs entirely off the existing `wplalr_log_recorded` action; it never touches
+ * the write path. Like Logger, it hooks nothing unless logging is enabled.
+ */
+class Notifier {
+
+	/**
+	 * Data layer.
+	 *
+	 * @var LogRepository
+	 */
+	protected $repository;
+
+	/**
+	 * Async single-event hook for per-event alerts.
+	 *
+	 * @var string
+	 */
+	const ALERT_HOOK = 'wplalr_send_login_alert';
+
+	/**
+	 * Recurring digest hook (scheduled in Installer).
+	 *
+	 * @var string
+	 */
+	const DIGEST_HOOK = 'wplalr_logs_digest_send';
+
+	/**
+	 * The constructor.
+	 *
+	 * @param LogRepository $repository Data layer.
+	 */
+	public function __construct( LogRepository $repository ) {
+		$this->repository = $repository;
+
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		add_action( 'wplalr_log_recorded', array( $this, 'maybe_queue_login_alert' ), 10, 2 );
+		add_action( self::ALERT_HOOK, array( $this, 'send_login_alert' ), 10, 1 );
+		add_action( self::DIGEST_HOOK, array( $this, 'send_digest' ) );
+	}
+
+	/**
+	 * Whether logging is switched on (same guard as Logger).
+	 *
+	 * @return bool
+	 */
+	protected function is_enabled() {
+		return 'yes' === get_option( 'wplalr_enable_logs', 'no' );
+	}
+
+	/**
+	 * Queue an async alert when a watched role logs in.
+	 *
+	 * @param int   $row_id The inserted row id.
+	 * @param array $data   The row data.
+	 * @return void
+	 */
+	public function maybe_queue_login_alert( $row_id, $data ) {
+		if ( ! isset( $data['event'] ) || 'login' !== $data['event'] ) {
+			return;
+		}
+
+		$notify_roles = array_values( (array) get_option( 'wplalr_logs_notify_roles', array() ) );
+
+		if ( empty( $notify_roles ) ) {
+			return;
+		}
+
+		$user_id = isset( $data['user_id'] ) ? absint( $data['user_id'] ) : 0;
+
+		if ( ! $user_id ) {
+			return;
+		}
+
+		// $data carries no roles, so look the user up.
+		$user = get_userdata( $user_id );
+
+		if ( ! $user instanceof \WP_User ) {
+			return;
+		}
+
+		if ( empty( array_intersect( (array) $user->roles, $notify_roles ) ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time(), self::ALERT_HOOK, array( (int) $row_id ) );
+	}
+
+	/**
+	 * Cron handler: re-read the row and email the alert.
+	 *
+	 * @param int $row_id The log row id.
+	 * @return void
+	 */
+	public function send_login_alert( $row_id ) {
+		$row = $this->repository->get( $row_id );
+
+		if ( null === $row ) {
+			return;
+		}
+
+		$user = $row['user_id'] ? get_userdata( $row['user_id'] ) : false;
+		$name = $user instanceof \WP_User ? $user->display_name : $row['username'];
+
+		$subject = sprintf(
+			/* translators: 1: site name, 2: username. */
+			__( '[%1$s] Login alert: %2$s signed in', 'wp-login-logout-redirect' ),
+			wp_specialchars_decode( (string) get_option( 'blogname' ), ENT_QUOTES ),
+			$name
+		);
+
+		$lines = array(
+			sprintf(
+				/* translators: %s: user display name / username. */
+				__( '%s just signed in to your site.', 'wp-login-logout-redirect' ),
+				$name
+			),
+			'',
+			sprintf( '%s: %s', __( 'Username', 'wp-login-logout-redirect' ), $row['username'] ),
+			sprintf( '%s: %s', __( 'Time', 'wp-login-logout-redirect' ), $row['created_at'] ),
+			sprintf( '%s: %s', __( 'IP address', 'wp-login-logout-redirect' ), $row['ip'] ),
+			sprintf( '%s: %s', __( 'Browser', 'wp-login-logout-redirect' ), trim( $row['browser'] . ' / ' . $row['device_os'], ' /' ) ),
+		);
+
+		$this->send(
+			'wplalr_log_notification_email',
+			array(
+				'to'      => $this->recipient(),
+				'subject' => $subject,
+				'body'    => $this->html_body( $subject, $lines ),
+				'headers' => $this->headers(),
+			),
+			array(
+				'row'  => $row,
+				'user' => $user,
+			)
+		);
+	}
+
+	/**
+	 * Cron handler: build and send the activity digest.
+	 *
+	 * @return void
+	 */
+	public function send_digest() {
+		$cadence = (string) get_option( 'wplalr_logs_digest', '' );
+
+		if ( '' === $cadence ) {
+			return;
+		}
+
+		$days  = $this->cadence_days( $cadence );
+		$stats = $this->repository->stats( $days );
+
+		$window_label = array(
+			'daily'   => __( 'last 24 hours', 'wp-login-logout-redirect' ),
+			'weekly'  => __( 'last 7 days', 'wp-login-logout-redirect' ),
+			'monthly' => __( 'last 30 days', 'wp-login-logout-redirect' ),
+		);
+		$window = isset( $window_label[ $cadence ] ) ? $window_label[ $cadence ] : '';
+
+		$subject = sprintf(
+			/* translators: 1: site name, 2: cadence (Daily/Weekly/Monthly). */
+			__( '[%1$s] %2$s login activity digest', 'wp-login-logout-redirect' ),
+			wp_specialchars_decode( (string) get_option( 'blogname' ), ENT_QUOTES ),
+			ucfirst( $cadence )
+		);
+
+		$lines = array(
+			sprintf(
+				/* translators: %s: time window, e.g. "last 7 days". */
+				__( 'Login activity for the %s:', 'wp-login-logout-redirect' ),
+				$window
+			),
+			'',
+			sprintf( '%s: %d', __( 'Successful logins', 'wp-login-logout-redirect' ), $stats['login'] ),
+			sprintf( '%s: %d', __( 'Logouts', 'wp-login-logout-redirect' ), $stats['logout'] ),
+			sprintf( '%s: %d', __( 'Failed logins', 'wp-login-logout-redirect' ), $stats['failed'] ),
+			sprintf( '%s: %d', __( 'Total events', 'wp-login-logout-redirect' ), $stats['total'] ),
+		);
+
+		$this->send(
+			'wplalr_log_digest_email',
+			array(
+				'to'      => $this->recipient(),
+				'subject' => $subject,
+				'body'    => $this->html_body( $subject, $lines ),
+				'headers' => $this->headers(),
+			),
+			array(
+				'cadence' => $cadence,
+				'stats'   => $stats,
+			)
+		);
+	}
+
+	/**
+	 * Filter the email payload and dispatch it via wp_mail.
+	 *
+	 * @param string $filter  Filter name for the payload.
+	 * @param array  $email   [ to, subject, body, headers ].
+	 * @param array  $context Extra context passed to the filter.
+	 * @return void
+	 */
+	protected function send( $filter, array $email, array $context = array() ) {
+		/**
+		 * Filter an outgoing notification email before it is sent.
+		 *
+		 * @param array $email   [ 'to', 'subject', 'body', 'headers' ].
+		 * @param array $context Extra context (row/user, or cadence/stats).
+		 */
+		$email = apply_filters( $filter, $email, $context );
+
+		if ( empty( $email['to'] ) ) {
+			return;
+		}
+
+		wp_mail( $email['to'], $email['subject'], $email['body'], $email['headers'] );
+	}
+
+	/**
+	 * Resolve the recipient address.
+	 *
+	 * @return string
+	 */
+	protected function recipient() {
+		$email = (string) get_option( 'wplalr_logs_notification_email', '' );
+
+		return '' !== $email ? $email : (string) get_option( 'admin_email' );
+	}
+
+	/**
+	 * HTML email headers.
+	 *
+	 * @return array
+	 */
+	protected function headers() {
+		return array( 'Content-Type: text/html; charset=UTF-8' );
+	}
+
+	/**
+	 * Days window for a digest cadence.
+	 *
+	 * @param string $cadence daily|weekly|monthly.
+	 * @return int
+	 */
+	protected function cadence_days( $cadence ) {
+		switch ( $cadence ) {
+			case 'weekly':
+				return 7;
+			case 'monthly':
+				return 30;
+			default:
+				return 1;
+		}
+	}
+
+	/**
+	 * Wrap body lines in a minimal HTML document.
+	 *
+	 * @param string   $heading Email heading.
+	 * @param string[] $lines   Body lines (blank string = paragraph break).
+	 * @return string
+	 */
+	protected function html_body( $heading, array $lines ) {
+		$body = '';
+
+		foreach ( $lines as $line ) {
+			$body .= '' === $line ? '<br>' : '<p style="margin:0 0 6px;">' . esc_html( $line ) . '</p>';
+		}
+
+		return sprintf(
+			'<div style="font-family:sans-serif;font-size:14px;color:#1e1e1e;">'
+			. '<h2 style="font-size:16px;">%1$s</h2>%2$s'
+			. '<hr style="border:none;border-top:1px solid #ddd;margin:16px 0;">'
+			. '<p style="font-size:12px;color:#757575;">%3$s</p></div>',
+			esc_html( $heading ),
+			$body,
+			esc_html( sprintf( /* translators: %s: site name. */ __( 'Sent by WP Login and Logout Redirect on %s.', 'wp-login-logout-redirect' ), get_bloginfo( 'name' ) ) )
+		);
+	}
+}

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -78,6 +78,9 @@ class SettingsController extends WP_REST_Controller {
 			'rules'                      => array_values( (array) get_option( RuleEngine::OPTION_RULES, array() ) ),
 			'wplalr_enable_logs'         => 'yes' === get_option( 'wplalr_enable_logs', 'no' ),
 			'wplalr_logs_retention_days' => (int) get_option( 'wplalr_logs_retention_days', 30 ),
+			'wplalr_logs_notification_email' => $this->get_notification_email(),
+			'wplalr_logs_notify_roles'   => array_values( (array) get_option( 'wplalr_logs_notify_roles', array() ) ),
+			'wplalr_logs_digest'         => (string) get_option( 'wplalr_logs_digest', '' ),
 		);
 
 		/**
@@ -119,6 +122,18 @@ class SettingsController extends WP_REST_Controller {
 			update_option( 'wplalr_logs_retention_days', absint( $request->get_param( 'wplalr_logs_retention_days' ) ) );
 		}
 
+		if ( $request->has_param( 'wplalr_logs_notification_email' ) ) {
+			update_option( 'wplalr_logs_notification_email', $this->sanitize_notification_email( $request->get_param( 'wplalr_logs_notification_email' ) ) );
+		}
+
+		if ( $request->has_param( 'wplalr_logs_notify_roles' ) ) {
+			update_option( 'wplalr_logs_notify_roles', $this->sanitize_notify_roles( $request->get_param( 'wplalr_logs_notify_roles' ) ) );
+		}
+
+		if ( $request->has_param( 'wplalr_logs_digest' ) ) {
+			update_option( 'wplalr_logs_digest', $this->sanitize_digest( $request->get_param( 'wplalr_logs_digest' ) ) );
+		}
+
 		return $this->get_settings( $request );
 	}
 
@@ -151,6 +166,66 @@ class SettingsController extends WP_REST_Controller {
 		}
 
 		return esc_url_raw( $value );
+	}
+
+	/**
+	 * The notification recipient, falling back to the site admin email.
+	 *
+	 * @return string
+	 */
+	protected function get_notification_email() {
+		$email = (string) get_option( 'wplalr_logs_notification_email', '' );
+
+		return '' !== $email ? $email : (string) get_option( 'admin_email' );
+	}
+
+	/**
+	 * Sanitize the notification email, falling back to the admin email when
+	 * empty or invalid.
+	 *
+	 * @param mixed $value Raw email from the request.
+	 * @return string
+	 */
+	protected function sanitize_notification_email( $value ) {
+		$email = is_string( $value ) ? sanitize_email( $value ) : '';
+
+		return is_email( $email ) ? $email : (string) get_option( 'admin_email' );
+	}
+
+	/**
+	 * Sanitize the notify-on-login roles against the site's registered roles.
+	 *
+	 * @param mixed $value Raw roles from the request.
+	 * @return array
+	 */
+	protected function sanitize_notify_roles( $value ) {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$valid = array_keys( wp_roles()->roles );
+		$clean = array();
+
+		foreach ( $value as $role ) {
+			$role = sanitize_key( $role );
+			if ( in_array( $role, $valid, true ) ) {
+				$clean[] = $role;
+			}
+		}
+
+		return array_values( array_unique( $clean ) );
+	}
+
+	/**
+	 * Sanitize the digest cadence to one of the allowed values.
+	 *
+	 * @param mixed $value Raw cadence from the request.
+	 * @return string '' | daily | weekly | monthly.
+	 */
+	protected function sanitize_digest( $value ) {
+		$value = is_string( $value ) ? $value : '';
+
+		return in_array( $value, array( '', 'daily', 'weekly', 'monthly' ), true ) ? $value : '';
 	}
 
 	/**
@@ -397,6 +472,24 @@ class SettingsController extends WP_REST_Controller {
 				'wplalr_logs_retention_days' => array(
 					'description' => __( 'Auto-delete log rows older than this many days (0 = keep forever).', 'wp-login-logout-redirect' ),
 					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'wplalr_logs_notification_email' => array(
+					'description' => __( 'Email address that login alerts and digests are sent to.', 'wp-login-logout-redirect' ),
+					'type'        => 'string',
+					'format'      => 'email',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'wplalr_logs_notify_roles'   => array(
+					'description' => __( 'Roles whose successful login triggers an email alert (empty = off).', 'wp-login-logout-redirect' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array( 'type' => 'string' ),
+				),
+				'wplalr_logs_digest'         => array(
+					'description' => __( 'Cadence of the activity digest email.', 'wp-login-logout-redirect' ),
+					'type'        => 'string',
+					'enum'        => array( '', 'daily', 'weekly', 'monthly' ),
 					'context'     => array( 'view', 'edit' ),
 				),
 			),

--- a/includes/WpLoginLogoutRedirect.php
+++ b/includes/WpLoginLogoutRedirect.php
@@ -107,7 +107,7 @@ final class WpLoginLogoutRedirect {
      */
     public function deactivate() {
         // Clear scheduled cron events; the table and its data are kept.
-        Logs\Installer::unschedule_cleanup();
+        Logs\Installer::unschedule_all();
     }
 
     /**
@@ -189,6 +189,7 @@ final class WpLoginLogoutRedirect {
         $this->container['logs_installer']  = new Logs\Installer();
         $this->container['logs_repository'] = new Logs\LogRepository();
         $this->container['logger']          = new Logs\Logger( $this->container['logs_repository'] );
+        $this->container['logs_notifier']   = new Logs\Notifier( $this->container['logs_repository'] );
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -25,6 +25,11 @@ This plugin also show each users last/latest login date and time on admin dashbo
 
 = Latest Features =
 * Every User last login date and time shown on dashbaord all users page.
+* Audit logging of login, logout and failed-login events with retention control.
+* Email alerts when a user with a selected role signs in, plus daily/weekly/monthly activity digests.
+
+= Privacy =
+When audit logging is enabled, each event stores the user's IP address and browser. Alert and digest emails include this login metadata and are sent only to the configured notification address (the site admin email by default). Notifications are off until you opt in.
 
 == Support ==
 If you find this plugin useful, consider supporting its development through a [donation](https://www.buymeacoffee.com/aiarnob).

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -574,6 +574,13 @@
 	border-top: 1px solid #f0f0f1;
 }
 
+/* ========== Field help ========== */
+.wplalr-field-help {
+	margin: 4px 0 0 0;
+	font-size: 12px;
+	color: #757575;
+}
+
 /* ========== Placeholder hint ========== */
 .wplalr-placeholder-hint {
 	margin: 4px 0 0 0;

--- a/src/components/OthersSettings.js
+++ b/src/components/OthersSettings.js
@@ -7,6 +7,8 @@ import {
 	Spinner,
 	ToggleControl,
 	SelectControl,
+	TextControl,
+	FormTokenField,
 } from '@wordpress/components';
 
 import { useSettings } from '../context/SettingsContext';
@@ -18,22 +20,55 @@ const RETENTION_OPTIONS = [
 	{ label: __( 'Keep forever', 'wp-login-logout-redirect' ), value: '0' },
 ];
 
+const DIGEST_OPTIONS = [
+	{ label: __( 'Off', 'wp-login-logout-redirect' ), value: '' },
+	{ label: __( 'Daily', 'wp-login-logout-redirect' ), value: 'daily' },
+	{ label: __( 'Weekly', 'wp-login-logout-redirect' ), value: 'weekly' },
+	{ label: __( 'Monthly', 'wp-login-logout-redirect' ), value: 'monthly' },
+];
+
+const ROLES = window.wplalrAdmin?.roles ?? {};
+
 const OthersSettings = () => {
 	const { settings, isSaving, saveSettings } = useSettings();
 
 	const [ enableLogs, setEnableLogs ] = useState( false );
 	const [ retentionDays, setRetentionDays ] = useState( '30' );
+	const [ notifyRoles, setNotifyRoles ] = useState( [] );
+	const [ notificationEmail, setNotificationEmail ] = useState( '' );
+	const [ digest, setDigest ] = useState( '' );
 
 	useEffect( () => {
 		setEnableLogs( !! settings.wplalr_enable_logs );
 		setRetentionDays( String( settings.wplalr_logs_retention_days ?? 30 ) );
-	}, [ settings.wplalr_enable_logs, settings.wplalr_logs_retention_days ] );
+		setNotifyRoles(
+			Array.isArray( settings.wplalr_logs_notify_roles )
+				? settings.wplalr_logs_notify_roles
+				: []
+		);
+		setNotificationEmail( settings.wplalr_logs_notification_email ?? '' );
+		setDigest( settings.wplalr_logs_digest ?? '' );
+	}, [
+		settings.wplalr_enable_logs,
+		settings.wplalr_logs_retention_days,
+		settings.wplalr_logs_notify_roles,
+		settings.wplalr_logs_notification_email,
+		settings.wplalr_logs_digest,
+	] );
+
+	const nameBySlug = ROLES;
+	const slugByName = Object.fromEntries(
+		Object.entries( ROLES ).map( ( [ slug, name ] ) => [ name, slug ] )
+	);
 
 	const handleSubmit = ( event ) => {
 		event.preventDefault();
 		saveSettings( {
 			wplalr_enable_logs: enableLogs,
 			wplalr_logs_retention_days: parseInt( retentionDays, 10 ),
+			wplalr_logs_notify_roles: notifyRoles,
+			wplalr_logs_notification_email: notificationEmail,
+			wplalr_logs_digest: digest,
 		} );
 	};
 
@@ -87,6 +122,94 @@ const OthersSettings = () => {
 								value={ retentionDays }
 								options={ RETENTION_OPTIONS }
 								onChange={ setRetentionDays }
+							/>
+						</div>
+					</CardBody>
+				</Card>
+
+				<Card className="wplalr-form-header-card">
+					<CardBody className="wplalr-form-section-header">
+						<h3 className="wplalr-section-title">
+							{ __(
+								'Notifications',
+								'wp-login-logout-redirect'
+							) }
+						</h3>
+						<p className="wplalr-section-description">
+							{ __(
+								'Email alerts and digests of login activity. Both require logging to be enabled above.',
+								'wp-login-logout-redirect'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+				<Card>
+					<CardBody className="wplalr-form-section-body">
+						<div className="wplalr-settings-group">
+							<FormTokenField
+								label={ __(
+									'Alert on login for roles',
+									'wp-login-logout-redirect'
+								) }
+								value={ notifyRoles.map(
+									( slug ) => nameBySlug[ slug ] ?? slug
+								) }
+								suggestions={ Object.values( nameBySlug ) }
+								onChange={ ( tokens ) =>
+									setNotifyRoles(
+										tokens
+											.map(
+												( token ) =>
+													slugByName[ token ] ?? token
+											)
+											.filter(
+												( slug ) => nameBySlug[ slug ]
+											)
+									)
+								}
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								__experimentalExpandOnFocus
+							/>
+							<p className="wplalr-field-help">
+								{ __(
+									'Send an email when a user with one of these roles signs in. Leave empty to disable alerts.',
+									'wp-login-logout-redirect'
+								) }
+							</p>
+						</div>
+						<div className="wplalr-settings-group">
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								type="email"
+								label={ __(
+									'Notification email',
+									'wp-login-logout-redirect'
+								) }
+								help={ __(
+									'Where alerts and digests are sent. Defaults to the site admin email.',
+									'wp-login-logout-redirect'
+								) }
+								value={ notificationEmail }
+								onChange={ setNotificationEmail }
+							/>
+						</div>
+						<div className="wplalr-settings-group">
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __(
+									'Digest summary',
+									'wp-login-logout-redirect'
+								) }
+								help={ __(
+									'Send a scheduled roll-up of login activity.',
+									'wp-login-logout-redirect'
+								) }
+								value={ digest }
+								options={ DIGEST_OPTIONS }
+								onChange={ setDigest }
 							/>
 						</div>
 						<Button


### PR DESCRIPTION
> ## 🧱 Stack level 4 of 4 — merge order #4
> This PR is part of a stacked chain. Merge **bottom-up** (closest to `develop` first):
> 1. #11 `feature/react-admin-settings` → `develop` *(merge first)*
> 2. #10 `feature/redirect-rule-engine` → `feature/react-admin-settings`
> 3. #9 `feature/admin-subpages` → `feature/redirect-rule-engine`
> 4. #8 `feature/audit-log-notifier` → `feature/admin-subpages` *(merge last)*
>
> **This PR: Level 4 — top of the stack, merge LAST** — check/merge after everything below it is merged.
## Summary

Implements `docs/notifier-plan.md` — email notifications hung off the existing audit-log write path. Two independent features, both **off by default** and gated behind `wplalr_enable_logs`:

- **Per-event alerts** — emails the configured recipient when a user whose role is in `wplalr_logs_notify_roles` logs in successfully. Sent via an async single-event (`wplalr_send_login_alert`) so login never blocks on SMTP.
- **Digest** — a scheduled daily/weekly/monthly roll-up of login activity (`wplalr_logs_digest_send`), built from `LogRepository::stats()`.

No changes to the write path; everything hangs off the existing `wplalr_log_recorded` action.

## Changes

**New**
- `includes/Logs/Notifier.php` — alerts + digest, HTML emails with filterable payloads (`wplalr_log_notification_email`, `wplalr_log_digest_email`).

**Changed**
- `includes/Logs/LogRepository.php` — `get( $id )` single-row fetch.
- `includes/Logs/Installer.php` — register non-core `monthly` schedule; reschedule digest on option change; `unschedule_all()` (old `unschedule_cleanup()` kept for back-compat).
- `includes/REST/SettingsController.php` — three new options in get/update/schema with sanitizers.
- `includes/WpLoginLogoutRedirect.php` — container wiring; `deactivate()` clears all cron.
- `src/components/OthersSettings.js` — additive "Notifications" card sharing the existing save round-trip.
- `docs/extensibility.md`, `readme.txt` — new filters + feature/privacy note.

## Testing
- `php -l` clean on all touched files
- `composer phpcs` — 9/9 pass
- `OthersSettings.js` lints clean; `npm run build` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)