### PR TITLE
Add admin subpages: audit logs, logged-in users, Others tab

### DIFF
--- a/docs/admin-subpages-plan.md
+++ b/docs/admin-subpages-plan.md
@@ -1,0 +1,269 @@
+# Admin Submenu Pages — separate React apps
+
+Status: **Spec / planning** (no code yet). Cross-cutting plumbing for shipping
+**Audit Logs** and **Logged-in Users** as their **own WordPress submenu pages**,
+each a separate React app — not tabs inside the existing settings SPA.
+
+Supersedes the "new tab in the existing SPA" UI approach in
+[`audit-logs-plan.md`](audit-logs-plan.md) §5 and
+[`logged-in-users-plan.md`](logged-in-users-plan.md) §4. Those features' PHP
+(repositories, REST controllers, loggers) are unchanged; only their **admin-page
+delivery** changes to a dedicated submenu page + dedicated bundle.
+
+---
+
+## 1. Target menu structure
+
+Today: one top-level menu (`add_menu_page`, slug `wplalr_login_logout_redirect`,
+screen `toplevel_page_wplalr_login_logout_redirect`) renders `#wplalr-settings`
+and mounts the `admin/script` bundle (Redirects + Rules tabs).
+
+Target: keep the top-level page, add two submenu pages under it.
+
+```
+Redirect Options (top-level, parent)        all three share the admin/script bundle
+├── Redirect Options   → admin.php?page=wplalr_login_logout_redirect   (#wplalr-settings)
+├── Audit Logs         → admin.php?page=wplalr_audit_logs              (#wplalr-audit-logs)
+└── Logged-in Users    → admin.php?page=wplalr_sessions                (#wplalr-sessions)
+```
+
+Each submenu page is a **distinct view**, mounted on its own root element. All
+three views ship in **one shared webpack bundle** (`admin/script`) enqueued on
+all three screens; the app renders whichever view's mount node is present on the
+current page (see §3 and §5). The pages are still separate WP URLs (full page
+loads between them) — only the JS bundle is shared.
+
+---
+
+## 2. PHP — menu registration (`includes/Settings.php`)
+
+`Settings::login_logout_redirect_menu()` keeps the `add_menu_page` call, then adds
+submenu pages and **captures the returned hook suffixes** (so `Assets` can match
+screens without hardcoding screen-id strings):
+
+```php
+$main = add_menu_page( /* …unchanged… */ 'wplalr_login_logout_redirect', [ $this, 'render_settings_page' ], 'dashicons-randomize' );
+
+// First submenu duplicates the parent with a cleaner label.
+add_submenu_page( 'wplalr_login_logout_redirect', __( 'Redirect Options', … ), __( 'Redirect Options', … ), 'manage_options', 'wplalr_login_logout_redirect', [ $this, 'render_settings_page' ] );
+
+$logs     = add_submenu_page( 'wplalr_login_logout_redirect', __( 'Audit Logs', … ),       __( 'Audit Logs', … ),       'manage_options', 'wplalr_audit_logs', [ $this, 'render_audit_logs_page' ] );
+$sessions = add_submenu_page( 'wplalr_login_logout_redirect', __( 'Logged-in Users', … ),  __( 'Logged-in Users', … ),  'manage_options', 'wplalr_sessions',   [ $this, 'render_sessions_page' ] );
+```
+
+- Expose the three hook suffixes (e.g. via a `Settings::get_page_hooks()` getter
+  or a shared constant/option) so `Assets` enqueues per screen.
+- Render callbacks each echo their own mount node:
+  - `render_settings_page()` → `<div id="wplalr-settings"></div>` (unchanged).
+  - `render_audit_logs_page()` → `<div id="wplalr-audit-logs"></div>`.
+  - `render_sessions_page()` → `<div id="wplalr-sessions"></div>`.
+- Optionally gate the Audit Logs / Sessions submenus on their feature toggles
+  (e.g. only show Audit Logs when logging exists). Recommended: always show; the
+  page itself handles the disabled/empty state.
+
+---
+
+## 3. Build — single entry (`webpack.config.js`)
+
+`webpack.config.js` stays **single-entry** — no change:
+
+```js
+entry: {
+  'admin/script': './src/admin.js',   // Redirects + Rules + Audit Logs + Sessions
+},
+```
+
+The one bundle contains all three views. `src/admin.js` is the single entry
+point; on boot it mounts whichever view's root element is present on the current
+WP screen (see §5). `@wordpress/scripts` still emits one `admin/script.asset.php`
+(deps + version) and one `admin/script.css`, all of which we already enqueue.
+
+**Why one bundle, not three:** the submenu pages are separate WP URLs (full page
+loads), but they need not be separate JS builds. Three entries would mean three
+`*.asset.php`/`*.css` pairs, a multi-entry webpack config, a screen→bundle
+enqueue map, and the `splitChunks`-vs-duplication question for the shared chrome.
+A single bundle removes all of that: shared modules are imported once with no
+duplication, and the bundle is already warm in the browser cache when the admin
+navigates to the second page. For an admin plugin this size the extra per-page
+payload (code for the other two views) is negligible. Only split into per-page
+bundles if one view's JS later grows large enough to be worth withholding from
+the other screens.
+
+**Shared code:** still extract the reusable chrome — `SettingsHeader`, `icons`,
+`LayoutStyles.css`, the snackbar/notices wiring, an `apiFetch` helper, and the
+new `PageShell` — into `src/shared/` for tidiness. With one bundle this is purely
+organizational (no duplication to avoid), but it keeps the per-view modules thin.
+
+---
+
+## 4. Assets — per-screen enqueue (`includes/Assets.php`)
+
+`enqueue_admin_scripts()` currently early-returns unless the screen is the
+top-level page. Generalize the guard to the **set of our three screens** (the
+hook suffixes captured in §2) — but enqueue the **same** `admin/script` bundle on
+all of them:
+
+```php
+$our_screens = [
+  $hooks['settings'],
+  $hooks['audit_logs'],
+  $hooks['sessions'],
+];
+if ( ! in_array( $screen->id, $our_screens, true ) ) { return; }
+```
+
+Then enqueue `assets/build/admin/script.js` (using `admin/script.asset.php` for
+deps/version) + `admin/script.css` + `wp-components` — the existing enqueue body,
+essentially unchanged; just the screen guard widens. No per-bundle map and no
+`enqueue_app()` indirection are needed, since there is one bundle.
+
+**Localized data** (`window.wplalrAdmin`) stays shared (`restRoot`, `roles`,
+`homeUrl`). The per-page extras the views need (e.g. `currentUserId` for the
+Sessions view's self-badging/guard, retention/notification defaults for the Logs
+view) can simply be localized **on every screen** — they're small and the single
+bundle is loaded everywhere anyway — or gated on `$screen->id` if you prefer to
+keep the payload minimal. Recommended: **localize them unconditionally** for
+simplicity; the app reads what the active view needs.
+
+---
+
+## 5. React — one app, three views (`src/`)
+
+A single entry point mounts whichever view's root element exists on the current
+WP screen. Each page renders exactly one of the three mount nodes (§2), so the
+loop finds at most one match:
+
+```js
+// src/admin.js  (the single entry)
+const views = {
+  'wplalr-settings':   SettingsApp,    // Redirects + Rules (existing)
+  'wplalr-audit-logs': AuditLogsApp,   // LogsViewer + useLogs
+  'wplalr-sessions':   SessionsApp,    // SessionsViewer + useSessions
+};
+
+for ( const [ id, App ] of Object.entries( views ) ) {
+  const el = document.getElementById( id );
+  if ( el ) {
+    createRoot( el ).render( <PageShell><App /></PageShell> );
+    break;
+  }
+}
+```
+
+- **`<SettingsApp>`** (existing Redirects + Rules SPA, factored out of the current
+  `src/admin.js` body) — keeps its internal Redirects/Rules hash tabs.
+- **`<AuditLogsApp>`** (new) — `LogsViewer` + its `useLogs` hook from the
+  audit-logs plan, as a standalone view rather than a routed tab.
+- **`<SessionsApp>`** (new) — `SessionsViewer` + `useSessions`.
+
+The three view components live under `src/components/` (or `src/views/`); there
+are **no** separate `src/audit-logs.js` / `src/sessions.js` entry files — only
+the one `src/admin.js` entry.
+
+**Cross-page navigation & visual consistency:** since these are now separate WP
+pages (full page loads between them), drop the in-app hash tabs for cross-feature
+nav. Instead each app reuses a shared `<PageShell>` that renders `SettingsHeader`
++ a secondary nav bar of plain links to the three `admin.php?page=…` URLs,
+highlighting the active page. The Redirects app keeps its internal Redirects/Rules
+hash tabs (those remain sub-views of one page); Audit Logs and Sessions are single
+views, so they need no internal router.
+
+---
+
+## 6. File checklist (delta vs. the feature plans)
+
+**Changed PHP**
+- `includes/Settings.php` — add submenu pages + render callbacks + hook-suffix
+  getter.
+- `includes/Assets.php` — widen the screen guard to our three hook suffixes
+  (same `admin/script` bundle on all) + localize the per-view extras.
+
+**Changed build**
+- `webpack.config.js` — **none** (stays single-entry).
+
+**New React**
+- `src/shared/` — extracted `SettingsHeader`, `icons`, styles, `PageShell`,
+  `apiFetch` helper, notices wiring.
+- View components/hooks per their own plans: `AuditLogsApp` (`LogsViewer` +
+  `useLogs`), `SessionsApp` (`SessionsViewer` + `useSessions`), and `SettingsApp`
+  (the existing Redirects + Rules SPA, extracted).
+
+**Changed React**
+- `src/admin.js` — becomes the mount-node dispatcher (§5); move the existing
+  Redirects/Rules app body into `<SettingsApp>`. Update imports to `src/shared/`.
+
+**Docs**
+- This file; UI sections of the two feature plans point here.
+
+---
+
+## 7. Build order
+
+1. **Menu + mounts:** add the two submenu pages and empty mount divs; confirm
+   they appear and load (blank) only on their screens.
+2. **Assets + dispatcher:** widen the `Assets` screen guard to enqueue
+   `admin/script` on all three screens; turn `src/admin.js` into the mount-node
+   dispatcher (§5). Confirm each page mounts only its own view.
+3. **Shared extraction:** move chrome to `src/shared/`, add `PageShell` +
+   cross-page nav; extract the existing app into `<SettingsApp>`.
+4. **Feature views:** build `AuditLogsApp` / `SessionsApp` per their plans.
+
+---
+
+## 8. Extensibility & the Pro seam
+
+The single-bundle decision (§3) is **build-time** and applies only to the free
+plugin. It does **not** constrain how a future Pro version extends these screens,
+because Pro never recompiles the free bundle. Spelling this out so the
+architecture stays Pro-ready:
+
+- **Pro ships as a separate plugin** that depends on the free one. (wordpress.org
+  forbids bundling paid upgrades in the free repo; licensing/updates run through a
+  separate channel.) It is installed alongside, activated independently, and
+  cannot touch the free build output.
+- **Pro extends at runtime, never at build time.** It enqueues its **own** small
+  bundle on these same screens (the hook suffixes are already public via the §2
+  getter) and registers `@wordpress/hooks` `addFilter(...)` calls against the
+  slots the free views expose — it does not fork or rebuild `admin/script`.
+- Therefore the free-vs-Pro split is **orthogonal** to whether the free app is one
+  bundle or three. Keep the single bundle; Pro composes on top of it.
+
+**Treat these seams as a public API** (version them; avoid breaking changes):
+
+JS (`@wordpress/hooks`), already named in the feature plans —
+- `wplalr_log_columns`, `wplalr_log_row_actions` (Logs view — CSV export, extra
+  columns land here in Pro).
+- `wplalr_session_columns`, `wplalr_session_row_actions` (Sessions view).
+
+PHP (actions/filters), already named in the feature plans —
+- `wplalr_after_resolve` (resolved redirect URL + matched `rule_id`).
+- `wplalr_log_recorded`, `wplalr_session_destroyed` (per-event extension points).
+- `wplalr_rest_log_item`, `wplalr_rest_logs_query_args` (REST shape extension).
+
+**`PageShell` cross-page nav (§5) should itself be filterable** so Pro can add its
+own submenu pages/links into the secondary nav without patching the free app —
+e.g. a `wplalr_admin_nav_items` filter feeding the link bar.
+
+**Revisit trigger (the one case to split a bundle):** if a *single view's* JS
+grows large — Logs analytics, or a Pro-heavy screen — split that one view into its
+own webpack entry then, and enqueue it only on its screen. Designing for that now
+is premature; the hook seams above are what actually matter for Pro.
+
+---
+
+## 9. Open questions (recommended defaults)
+
+- Keep a top-level "Redirect Options" page, or convert the top level to a generic
+  parent? → **Keep Redirect Options as the landing page** (least disruption;
+  existing bookmarks/links still work).
+- Separate bundles vs. one bundle mounting different roots per page? →
+  **One shared bundle** mounting the matching root per screen (§3, §5). Removes
+  multi-entry webpack, the screen→bundle map, and the splitChunks/duplication
+  question; per-page payload overhead is negligible for an admin plugin this
+  size, and the bundle is cache-warm by the second page. Revisit per-page bundles
+  only if one view's JS grows large enough to be worth withholding.
+- Cross-page nav as a secondary link bar vs. relying on the WP submenu only? →
+  **Secondary link bar** in the shared `PageShell` for discoverability, in
+  addition to the WP submenu.
+- Gate Audit Logs / Sessions submenus behind feature/enable toggles? → **Always
+  visible**; pages render their own disabled/empty states.

--- a/docs/audit-logs-plan.md
+++ b/docs/audit-logs-plan.md
@@ -1,0 +1,385 @@
+# Audit Logs — Implementation Plan
+
+Status: **Spec / planning** (no code yet). Next phase after the rule engine
+(Phases 1–4 of [`free-pro-roadmap.md`](free-pro-roadmap.md)) lands.
+
+Goal: record an auditable trail of login / logout / failed-login events into a
+**custom database table**, and surface it as a paginated, filterable, searchable
+**Logs** tab in the existing React admin app — modeled on FluentAuth
+(`fluent-security`)'s `fls_auth_logs` table and `LogsController`, but adapted to
+this plugin's conventions (PSR-4 `includes/`, `WP_REST_Controller`, `@wordpress`
+React app, PHPCS/WPCS).
+
+This extends our existing differentiator: we already track **last login** as user
+meta (`UserLoginTime`). Audit logs generalize that into a full, queryable event
+history — something LoginWP and Sky do not ship as core, and which FluentAuth only
+offers inside a heavier security suite.
+
+---
+
+## 1. Reference: how FluentAuth does it
+
+Verified against actual source, not marketing:
+
+- **Table** `{prefix}fls_auth_logs` created in `Activator::migrateLogsTable()` via
+  `dbDelta()`, guarded by a `SHOW TABLES LIKE` check. Columns: `id`, `username`,
+  `user_id`, `count`, `agent`, `browser`, `device_os`, `ip`, `status`,
+  `error_code`, `media`, `description`, `created_at`, `updated_at`, with indexes
+  on `created_at`, `ip`, `status`, `media`, `user_id`, `username`.
+- **Writes** happen in `LoginSecurityHandler`: `logAuthSuccess()` on
+  `wp_login`, `logFailedAuth()` on `wp_login_failed`, plus a `logBlockedAuth()`
+  for rate-limited attempts (security feature — **out of scope** for us). Each
+  write is gated behind a setting (`enable_auth_logs`). Repeated blocked attempts
+  from one IP increment `count` rather than inserting a new row.
+- **Read API** `LogsController`: `getLogs` (paginate + `status` filter + `LIKE`
+  search on `username`/`media`, returns `human_time_diff`), `deleteLog`,
+  `deleteAllLog` (TRUNCATE), `quickStats` (grouped counts by status over a date
+  range).
+- **Retention** `Helper::cleanUpLogs()` deletes rows older than
+  `auto_delete_logs_day`, run from a scheduled `daily` cron event registered in
+  the activator.
+- FluentAuth uses its own query-builder (`flsDb()`); **we will use `$wpdb`
+  directly** with prepared statements to avoid a dependency.
+
+We deliberately drop FluentAuth's security-suite pieces (blocked-login counting,
+login-attempt limiting, magic-login hash table). We keep the **audit trail**:
+login success, logout, and failed login.
+
+---
+
+## 2. Product decisions to confirm
+
+These shape the build; defaults are recommended in §11.
+
+1. **Logout logging** — FluentAuth logs login success/fail but not logout. Since
+   this plugin is fundamentally about *both* login and logout, we should log
+   logout too (`wp_logout`). Recommended: **yes, log logout**.
+2. **Free vs Pro split** — basic logging + viewer (this plan) is **Free** and a
+   natural extension of the Last-Login differentiator. CSV export and extended
+   analytics are already marked **Pro** in the roadmap (§3 of free-pro-roadmap).
+3. **Default on/off** — installs that never open the page shouldn't silently grow
+   a table. Recommended: logging **off by default**, enabled via a toggle on the
+   Logs tab; show an empty state explaining how to enable.
+4. **GDPR/PII** — IP address + user agent are personal data. Provide retention
+   (auto-delete after N days) and a "delete all" action; document it. Recommended
+   retention default: **30 days**.
+
+---
+
+## 3. Data model
+
+New custom table `{prefix}wplalr_auth_logs`. No migration of existing data;
+`wplalr_last_login` user meta stays as-is (the Last Login column keeps working,
+optionally backed by the new table later — not in this phase).
+
+```sql
+CREATE TABLE {prefix}wplalr_auth_logs (
+  id          BIGINT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  user_id     BIGINT UNSIGNED NULL,
+  username    VARCHAR(192) NOT NULL,
+  event       VARCHAR(20)  NOT NULL,          -- 'login' | 'logout' | 'failed'
+  status      VARCHAR(20)  NOT NULL DEFAULT 'success', -- 'success' | 'failed'
+  redirect_url VARCHAR(255) NULL,             -- the resolved redirect target
+  rule_id     VARCHAR(64)  NULL,              -- which RuleEngine rule matched (or null)
+  ip          VARCHAR(50)  NULL,
+  agent       VARCHAR(255) NULL,
+  browser     VARCHAR(50)  NULL,
+  device_os   VARCHAR(50)  NULL,
+  error_code  VARCHAR(50)  NULL DEFAULT '',
+  description TINYTEXT     NULL,
+  created_at  TIMESTAMP    NULL,
+  KEY created_at (created_at),
+  KEY user_id   (user_id),
+  KEY event     (event(20)),
+  KEY ip        (ip(50))
+) {charset_collate};
+```
+
+Notes:
+- `redirect_url` + `rule_id` are **our additions** over FluentAuth — they tie each
+  event back to the redirect that fired, which is this plugin's domain. `rule_id`
+  references the stable id in `wplalr_redirect_rules`.
+- Drop FluentAuth's `count`/`media`/`updated_at` (those served blocked-attempt
+  coalescing and magic-login, which we don't have). One row per event.
+
+### Last Login integration (Free)
+
+The plugin already tracks last login as `wplalr_last_login` user meta and renders
+a sortable **Last Login** column via `UserLoginTime`. The audit log generalizes
+that into a full event history. Decisions to keep them coherent — **all Free**:
+
+- **Keep `wplalr_last_login` user meta as the source of truth for the column.**
+  It's O(1) to read per user-row and works even when logging is toggled off. Do
+  **not** make the users-list column query the logs table (would be a slow join
+  across the user list). `UserLoginTime` stays as-is.
+- **`Logger` updates both** on `wp_login`: it writes the audit row *and* refreshes
+  `wplalr_last_login` (or `UserLoginTime` keeps owning the meta and `Logger` only
+  writes the row — pick one writer; recommended: `UserLoginTime` keeps the meta,
+  `Logger` adds the row, so the column never regresses if logging is off).
+- **Enrich the column from the log when available:** when logging is on, the
+  Last Login column tooltip/secondary line can show IP + browser from the latest
+  `login` row for that user (cheap single-row lookup, cached per request). Pure
+  enhancement; degrades to the plain timestamp when logging is off.
+- **Per-user history:** the Logs tab's search already filters by username, giving
+  a per-user login history for free — no extra UI needed in v1. (Pro adds last
+  *logout* + login *count* analytics on top.)
+
+New options:
+
+| Option key | Tier | Purpose |
+|---|---|---|
+| `wplalr_enable_logs` | Free | `'yes'`/`'no'` — master switch for logging |
+| `wplalr_logs_retention_days` | Free | int — auto-delete rows older than this (0 = keep forever) |
+| `wplalr_db_version` | Free | schema version string, drives `dbDelta` upgrades |
+| `wplalr_logs_notification_email` | Free | where event-notification emails are sent (default `{admin_email}`) |
+| `wplalr_logs_notify_roles` | Free | email an admin when a user of one of these roles logs in (`[]` = off) |
+| `wplalr_logs_digest` | Free | `''`/`'daily'`/`'weekly'`/`'monthly'` — scheduled login-activity digest email |
+
+### Settings considered, mapped to FluentAuth
+
+FluentAuth's log layer exposes more than retention. The full set and our decision:
+
+| FluentAuth setting | Our decision |
+|---|---|
+| `enable_auth_logs` | **Free** — `wplalr_enable_logs` |
+| `auto_delete_logs_day` | **Free** — `wplalr_logs_retention_days` (the field in the FluentAuth screenshot) |
+| `notification_email` | **Free** — `wplalr_logs_notification_email` |
+| `notification_user_roles` | **Free** — `wplalr_logs_notify_roles` (per-event email alerts) |
+| `digest_summary` | **Free** — `wplalr_logs_digest` (scheduled roll-up email) |
+| `notify_on_blocked` | **Dropped** — security-only; we have no login-blocking |
+
+Per-event email alerts and the digest ship in Free as a differentiator over
+LoginWP/Sky. Implementation: a `Notifier` listens on `wplalr_log_recorded`
+(per-event, gated on `wplalr_logs_notify_roles`); the digest rides a scheduled
+cron event (`wplalr_logs_digest` cadence) reusing the §6 cron infrastructure.
+
+---
+
+## 4. PHP architecture (aligned to `includes/`)
+
+All classes in namespace `PluginizeLab\WpLoginLogoutRedirect`, PSR-4 from
+`includes/`, registered in `WpLoginLogoutRedirect::init_classes()`'s `$container`.
+
+### 4.1 `includes/Logs/Installer.php` (new)
+- `maybe_install()` — runs `dbDelta()` for the table when `wplalr_db_version` is
+  missing/stale (mirrors `Activator::migrateLogsTable`). Call from the existing
+  `WpLoginLogoutRedirect::activate()` (currently empty) **and** from an
+  `admin_init`/`plugins_loaded` version check so updates without reactivation
+  still migrate.
+- Registers/unregisters the daily cleanup cron event.
+
+### 4.2 `includes/Logs/LogRepository.php` (new)
+Thin `$wpdb` data layer — the only place that touches the table:
+- `insert( array $data ): int`
+- `query( array $args ): array` — paginated list: `page`, `per_page`, `event`,
+  `status`, `search` (LIKE on `username`/`ip`), `orderby`, `order`. Returns
+  `[ 'items' => [...], 'total' => int, 'pages' => int ]`. All inputs sanitized;
+  `orderby`/`order` allowlisted; queries via `$wpdb->prepare`.
+- `delete( int $id ): bool`
+- `delete_all(): void` — `TRUNCATE`.
+- `stats( string $range ): array` — grouped counts by `event`/`status` for the
+  dashboard cards (mirrors `quickStats`).
+- `purge_older_than( int $days ): int` — used by cron.
+
+### 4.3 `includes/Logs/Logger.php` (new)
+Hooks the WP auth lifecycle and writes through `LogRepository`. Gated on
+`wplalr_enable_logs === 'yes'`:
+- `wp_login` (prio 20, 2 args) → success row. `UserLoginTime` keeps owning the
+  `wplalr_last_login` meta (so the Last Login column never regresses when logging
+  is off); `Logger` only adds the audit row. Capture the resolved redirect: have
+  `Redirection` stash the
+  resolved URL + matched `rule_id` (e.g. via a transient-free request-scoped
+  property or a `do_action( 'wplalr_after_resolve', ... )` payload that Logger
+  listens to). The roadmap already plans `wplalr_after_resolve` — **reuse it**.
+- `wp_login_failed` → failed row (status `failed`, `error_code` from the
+  `WP_Error`/username).
+- `wp_logout` → logout row.
+- A small `UserAgent` parser (`includes/Logs/UserAgent.php`) for `browser` /
+  `device_os` — a compact regex map; do **not** vendor FluentAuth's
+  `BrowserDetection`. Keep it dependency-free and PHPCS-clean.
+
+Each write fires `do_action( 'wplalr_log_recorded', $row_id, $data )` so the
+notifier (and Pro geo-IP enrichment) can hook it.
+
+### 4.3a `includes/Logs/Notifier.php` (new, Free)
+Email layer driven by the logs:
+- Listens on `wplalr_log_recorded`; when the event is a successful login and the
+  user's role intersects `wplalr_logs_notify_roles`, sends an alert email to
+  `wplalr_logs_notification_email` (`{admin_email}` token resolved). No-op when
+  the roles list is empty.
+- Digest: handler for the `wplalr_logs_digest` cron event (cadence from the
+  option) builds a roll-up (counts + recent rows via `LogRepository::stats`/
+  `query`) and emails it. Templated, `wp_mail`-based; filterable subject/body via
+  `wplalr_log_notification_email` / `wplalr_log_digest_email`.
+
+### 4.4 `includes/REST/LogsController.php` (new)
+A second `WP_REST_Controller`, namespace `wplalr/v1`, base `logs`, cap
+`manage_options`. Registered alongside `SettingsController` in
+`WpLoginLogoutRedirect::register_rest_routes()`:
+- `GET    wplalr/v1/logs` → list (query args above).
+- `DELETE wplalr/v1/logs/(?P<id>\d+)` → delete one.
+- `DELETE wplalr/v1/logs` → delete all.
+- `GET    wplalr/v1/logs/stats` → dashboard cards.
+- `GET/POST wplalr/v1/logs/settings` *(or fold into the existing settings
+  endpoint)* → read/write `wplalr_enable_logs` + `wplalr_logs_retention_days`.
+  Recommended: **fold the two log options into the existing
+  `wplalr/v1/settings`** payload to keep one settings round-trip; keep the log
+  *data* endpoints separate. Each item includes a computed `human_time_diff`.
+
+Extension filters mirroring the roadmap: `wplalr_rest_log_item`,
+`wplalr_rest_logs_query_args`.
+
+### 4.5 Wiring
+- `init_classes()`: add `logs_repository`, `logger`, `logs_installer` (or run the
+  installer's version check directly). `Redirection` gets a way to expose the
+  resolved redirect/rule to `Logger` (via the existing `wplalr_after_resolve`
+  action).
+- `WpLoginLogoutRedirect::activate()`: call `Installer::maybe_install()` +
+  schedule cron.
+- `deactivate()`: clear the cron event (keep the table + data).
+
+---
+
+## 5. React admin UI (`src/`)
+
+**Delivery: a dedicated submenu page rendered as one view of the shared React
+app** — see [`admin-subpages-plan.md`](admin-subpages-plan.md). (Supersedes the
+earlier "Logs tab inside the existing SPA" approach.) An **Audit Logs** submenu
+under Redirect Options (`admin.php?page=wplalr_audit_logs`), mount node
+`#wplalr-audit-logs`. The single `admin/script` bundle is enqueued on this screen
+and its mount-node dispatcher renders `<AuditLogsApp>` — no separate webpack
+entry/bundle.
+
+- **`<AuditLogsApp>`** (new view) — mounted on `#wplalr-audit-logs` by the
+  `src/admin.js` dispatcher, wrapped in the shared `PageShell` (header +
+  cross-page nav). Single view, no internal router.
+- **`src/components/LogsViewer.js`** (new) — top section:
+  - **Stat cards** (success / failed / logout counts) from `/logs/stats`.
+  - **Enable logging** toggle + **retention** field.
+  - **Notifications** sub-panel: notify-on-login role multi-select
+    (`wplalr_logs_notify_roles`), notification email, and digest cadence
+    `SelectControl` (off / daily / weekly / monthly). All Free.
+  - **Toolbar**: search box, event/status filter `SelectControl`, "Delete all"
+    (with a confirm `Modal`).
+  - **Table**: paginated rows (time, user, event, status, IP, browser/OS,
+    redirect URL, delete action). Use `@wordpress/components` (`Card`, `Spinner`,
+    `Button`, `SelectControl`) to match existing styling; a lightweight table —
+    no new table dep needed.
+  - **Empty state** when logging is off or no rows yet.
+- **`src/context/`** — either extend `SettingsContext` or add a small
+  `useLogs()` hook doing `apiFetch` against `/wplalr/v1/logs` with pagination
+  state. Recommended: a dedicated hook to keep `SettingsContext` focused.
+- Reuse the `@wordpress/notices` snackbar pattern for delete confirmations.
+- Pro slots: surface optional columns/actions via `wplalr_log_columns` /
+  `wplalr_log_row_actions` `@wordpress/hooks` filters (CSV export button lands
+  here in Pro).
+
+---
+
+## 6. Retention & cron
+
+- Daily event `wplalr_logs_cleanup` (registered on activation, like FluentAuth's
+  `fluent_auth_daily_tasks`). Handler calls
+  `LogRepository::purge_older_than( wplalr_logs_retention_days )` when retention
+  > 0.
+- Digest event `wplalr_logs_digest_send` — (re)scheduled to match the
+  `wplalr_logs_digest` cadence whenever the option changes; cleared when set to
+  `''`. Handler → `Notifier` builds and sends the roll-up.
+- Unschedule both on deactivation.
+
+---
+
+## 7. Security / privacy
+
+- All reads/writes capability-gated (`manage_options`) and nonce-checked via the
+  REST cookie auth the existing controller already uses.
+- Every dynamic query through `$wpdb->prepare`; `orderby`/`order` allowlisted;
+  `esc_url_raw` for `redirect_url`; `sanitize_text_field` for the rest.
+- Document the table + IP/UA collection in `readme.txt` (privacy section) and
+  provide the delete-all + retention controls for GDPR.
+- Logging **off by default** so no PII is collected unless the admin opts in.
+
+---
+
+## 8. Testing / acceptance
+
+- `composer phpcs` + `php -l` clean on all new PHP.
+- `npm run build` + `npm run lint:js` clean.
+- Manual (extend [`browser-test-cases.md`](browser-test-cases.md)):
+  successful login writes a `login`/`success` row with the right redirect URL +
+  matched rule id; bad password writes a `failed` row; logout writes a `logout`
+  row; filters/search/pagination/delete/delete-all work; toggling logging off
+  stops new rows; retention cron prunes old rows; table is created on
+  activation and on version bump without reactivation.
+- Multisite: install per-blog (loop `get_sites()` in the activator, like
+  FluentAuth) — or document single-site only for v1.
+
+---
+
+## 9. File checklist
+
+**New PHP**
+- `includes/Logs/Installer.php`
+- `includes/Logs/LogRepository.php`
+- `includes/Logs/Logger.php`
+- `includes/Logs/Notifier.php`
+- `includes/Logs/UserAgent.php`
+- `includes/REST/LogsController.php`
+
+**Changed PHP**
+- `includes/WpLoginLogoutRedirect.php` (container wiring, activate/deactivate,
+  REST registration, version check)
+- `includes/Redirection.php` (expose resolved URL + rule id via
+  `wplalr_after_resolve`)
+
+**New React**
+- `src/components/AuditLogsApp.js` (new view, rendered by the `src/admin.js`
+  dispatcher — no new webpack entry)
+- `src/components/LogsViewer.js`
+- `src/hooks/useLogs.js`
+
+**Changed build / PHP (see [`admin-subpages-plan.md`](admin-subpages-plan.md))**
+- `webpack.config.js` — none (single entry)
+- `src/admin.js` (register the `#wplalr-audit-logs` → `<AuditLogsApp>` mount)
+- `includes/Settings.php` (Audit Logs submenu + mount node)
+- `includes/Assets.php` (enqueue `admin/script` on the Audit Logs screen)
+
+**Docs / meta**
+- `readme.txt` privacy + changelog
+- `docs/extensibility.md` (new filters/actions)
+- `docs/browser-test-cases.md` (Logs tab cases)
+
+---
+
+## 10. Build order (phased)
+
+1. **DB + write path (no UI):** `Installer` + `LogRepository` + `Logger`;
+   activation hook creates the table; logging gated behind `wplalr_enable_logs`.
+   Acceptance: rows appear for login/logout/failed via direct DB inspection.
+2. **Read REST API:** `LogsController` (list/stats/delete/delete-all) + fold the
+   two options into `/settings`.
+3. **React Logs tab:** `LogsViewer` (table, filters, search, pagination, stat
+   cards, enable toggle, retention, notifications sub-panel, delete actions).
+4. **Retention cron + `Notifier` (per-event alerts + digest cron) + privacy docs
+   + extension filters.**
+5. *(Pro, later)* CSV export, extended analytics (login counts, last logout),
+   geo-IP enrichment — hooking the Phase-4 filters.
+
+---
+
+## 11. Open questions (recommended defaults)
+
+- Log logout events? → **Yes** (core to this plugin's purpose).
+- Logging default state? → **Off**, opt-in via the Logs tab.
+- Retention default? → **30 days**, configurable (0 = forever).
+- Fold log-settings into `/wplalr/v1/settings` or a separate endpoint? →
+  **Fold the two options into `/settings`**, keep log *data* endpoints separate.
+- Multisite per-blog install in v1, or single-site only? → **Single-site for v1**,
+  multisite loop as a fast follow.
+- Browser/OS parsing: ship a tiny regex parser vs. skip browser/OS columns for
+  v1? → **Tiny parser** (small, dependency-free) — or defer the two columns if it
+  risks PHPCS noise.
+- Email notifications + digest summary (FluentAuth's `notification_*` /
+  `digest_summary`): Free or Pro? → **Free (decided)** — shipped in Free as a
+  differentiator over LoginWP/Sky via `includes/Logs/Notifier.php`. Pro keeps CSV
+  export + extended analytics + geo-IP.

--- a/docs/browser-test-cases-subpages.md
+++ b/docs/browser-test-cases-subpages.md
@@ -1,0 +1,342 @@
+# Browser test cases — Admin subpages (Claude-in-Chrome)
+
+Manual/automated UI test plan for the **admin submenu pages** added in
+`feature/admin-subpages`: the **Audit Logs** page, the **Logged-in Users** page
+(force logout), the **Others** settings tab (logging toggle + retention), and the
+shared cross-page navigation. Written so it can be driven by the Claude-in-Chrome
+browser tools. Each case lists the browser actions and how to verify the outcome
+(screenshot, `wp-cli`, or console).
+
+Companion to [`browser-test-cases.md`](browser-test-cases.md), which covers the
+Redirects + Rules SPA. This file only covers the new subpages.
+
+## Environment & setup
+
+- **Redirect Options (settings):** `https://woocommerce.test/wp-admin/admin.php?page=wplalr_login_logout_redirect`
+- **Audit Logs:** `https://woocommerce.test/wp-admin/admin.php?page=wplalr_audit_logs`
+- **Logged-in Users:** `https://woocommerce.test/wp-admin/admin.php?page=wplalr_sessions`
+- **Auth:** must be logged in as an admin (`manage_options`). If a page shows the
+  WP login form, stop and ask the user to log in.
+- **Mount nodes:** Settings → `#wplalr-settings`, Audit Logs → `#wplalr-audit-logs`,
+  Logged-in Users → `#wplalr-sessions`. All three share the one `admin/script`
+  bundle; each page mounts only its own view.
+- **Tooling:** start with `tabs_context_mcp`, then `navigate`; capture state with
+  `computer` screenshots; debug with `read_console_messages`.
+
+### State helpers (run in the project dir via shell)
+
+```bash
+# Logging on/off + retention (managed on the Others tab)
+wp option get wplalr_enable_logs            # 'yes' | 'no'
+wp option get wplalr_logs_retention_days    # integer (days; 0 = keep forever)
+wp option update wplalr_enable_logs yes
+wp option update wplalr_logs_retention_days 30
+
+# Inspect / wipe the audit-log table
+wp db query "SELECT COUNT(*) FROM $(wp db prefix --allow-root 2>/dev/null)wplalr_auth_logs;"
+wp db query "TRUNCATE TABLE $(wp db prefix --allow-root 2>/dev/null)wplalr_auth_logs;"
+
+# Seed an event without a real login (fires the logger via wp_login)
+wp eval 'do_action( "wp_login", "admin", get_user_by( "id", 1 ) );'
+```
+
+### Pass criteria for every case
+
+- No uncaught errors in `read_console_messages` (the benign
+  `InvalidStateError: Transition was aborted...` at `:0:0` is a Chrome
+  view-transition artifact and may be ignored — it has no plugin stack).
+- No PHP critical-error snackbar ("There has been a critical error on this website").
+- The browser harness must **not** trigger native `alert`/`confirm` dialogs. All
+  destructive flows here use a `@wordpress/components` `<Modal>` (in-page), not a
+  browser confirm — so they are safe to drive. Do not click WP core "Empty Trash"
+  style buttons elsewhere.
+
+---
+
+## Menu & navigation
+
+## TC-S01 — Submenu pages registered under Redirect Options
+
+**Steps**
+1. `navigate` to the settings URL.
+2. Hover/expand the **Redirect Options** menu in the WP admin sidebar. Screenshot.
+
+**Expected**
+- Three submenu items: **Redirect Options**, **Audit Logs**, **Logged-in Users**.
+- Their links point to `admin.php?page=wplalr_login_logout_redirect`,
+  `?page=wplalr_audit_logs`, and `?page=wplalr_sessions` respectively.
+
+## TC-S02 — Cross-page nav bar renders on every subpage
+
+**Steps**
+1. `navigate` to each of the three URLs in turn; screenshot each.
+
+**Expected**
+- Each page shows the shared `PageShell` header ("WP Login and Logout Redirect")
+  and a secondary nav bar (`.wplalr-page-nav`) with three links: Redirect Options,
+  Audit Logs, Logged-in Users.
+- The link for the **current** page has the `is-active` class (purple underline).
+
+## TC-S03 — Nav links perform full-page loads to the right view
+
+**Steps**
+1. From Audit Logs, click the **Logged-in Users** nav link.
+2. Confirm the URL changes to `?page=wplalr_sessions` and the Sessions view mounts.
+3. Click **Redirect Options**; confirm Redirects + Rules SPA mounts.
+
+**Expected**
+- Each click is a normal full page load (URL changes, not just a hash).
+- Only the destination view's mount node is present; no console errors about a
+  missing root.
+
+## TC-S04 — Only the matching view mounts per screen
+
+**Steps**
+1. On Audit Logs, run in console:
+   `document.getElementById('wplalr-audit-logs') && !document.getElementById('wplalr-sessions') && !document.getElementById('wplalr-settings')`.
+
+**Expected**
+- Evaluates truthy — exactly one mount node exists per page (the dispatcher in
+  `src/admin.js` mounts only the present root).
+
+---
+
+## Others tab (logging settings)
+
+## TC-S05 — Others tab reachable from the settings SPA
+
+**Steps**
+1. `navigate` to the settings URL, then click the **Others** tab (hash `#/others`).
+2. Screenshot.
+
+**Expected**
+- "Audit Logging" card with an **Enable logging** toggle and a **Delete logs older
+  than** select (7 / 30 / 90 days / Keep forever).
+- A **Save Changes** button.
+
+## TC-S06 — Enable logging persists
+
+**Steps**
+1. Pre-state: `wp option update wplalr_enable_logs no`.
+2. On the Others tab, turn **Enable logging** on; click **Save Changes**.
+   Screenshot promptly (snackbar auto-dismisses).
+
+**Expected**
+- "Settings saved successfully!" snackbar.
+- `wp option get wplalr_enable_logs` → `yes`.
+
+## TC-S07 — Retention select persists
+
+**Steps**
+1. On the Others tab, set **Delete logs older than** = `90 days`; Save.
+
+**Expected**
+- `wp option get wplalr_logs_retention_days` → `90`.
+- Set to **Keep forever** and Save → option becomes `0`.
+
+## TC-S08 — Round-trip on reload
+
+**Steps**
+1. Set logging on + retention 7 days, Save.
+2. Full `navigate` reload of the settings URL `#/others`.
+
+**Expected**
+- Toggle re-renders **on**; select re-renders **7 days** (values fetched fresh
+  from `/wplalr/v1/settings`).
+
+---
+
+## Audit Logs page
+
+## TC-S09 — Logging OFF empty state
+
+**Steps**
+1. `wp option update wplalr_enable_logs no`.
+2. `navigate` to the Audit Logs URL. Screenshot.
+
+**Expected**
+- Four stat cards (Logins / Logouts / Failed logins / Total events), all `0` when
+  the table is empty.
+- Empty message: "Logging is off. Enable it on the Others tab under Redirect
+  Options to start recording login activity."
+
+## TC-S10 — Logging ON, no rows yet
+
+**Steps**
+1. `wp option update wplalr_enable_logs yes`; truncate the log table.
+2. `navigate` to Audit Logs. Screenshot.
+
+**Expected**
+- Empty message switches to "No log entries match your filters yet."
+- Toolbar shows Search, Event filter, **Refresh**, and a disabled **Delete all**
+  (disabled because total is 0).
+
+## TC-S11 — Recorded events appear with correct columns
+
+**Steps**
+1. With logging on, seed an event:
+   `wp eval 'do_action( "wp_login", "admin", get_user_by( "id", 1 ) );'`
+   (or perform a real login in a separate profile).
+2. `navigate` to Audit Logs (or click **Refresh**). Screenshot.
+
+**Expected**
+- A row appears with columns: Time (relative, hover shows full datetime), User
+  (`admin`), Event badge (**Login**), IP, Browser / OS, Redirect.
+- The **Logins** and **Total events** stat cards increment.
+
+## TC-S12 — Event filter
+
+**Steps**
+1. Seed at least one `login` and one `failed` event
+   (`wp eval 'do_action( "wp_login_failed", "baduser", new WP_Error() );'`).
+2. On Audit Logs, set the Event filter to **Failed login**. Screenshot.
+
+**Expected**
+- Only `failed` rows show; the failed badge uses the `is-failed` (red) style and
+  may show an error code. Switching back to **All events** restores the full list.
+
+## TC-S13 — Search by username / IP
+
+**Steps**
+1. In the Search box type a known username (e.g. `admin`).
+
+**Expected**
+- List narrows to matching rows (server-side `username`/`ip` LIKE filter). Clearing
+  the box restores all rows.
+
+## TC-S14 — Delete a single entry
+
+**Steps**
+1. Click the trash icon on a row.
+
+**Expected**
+- The row is removed and the matching stat card decrements.
+- `wp db query "SELECT COUNT(*) ..."` reflects one fewer row.
+
+## TC-S15 — Delete all (modal confirm)
+
+**Steps**
+1. Click **Delete all**. An in-page `<Modal>` titled "Delete all logs?" appears.
+2. Click **Delete all** inside the modal. Screenshot.
+
+**Expected**
+- Modal copy: "This permanently removes every recorded event. This cannot be
+  undone." **Cancel** closes with no change.
+- Confirming empties the table; stat cards reset to 0; empty state returns.
+- This is a component Modal, **not** a browser confirm — safe to automate.
+
+## TC-S16 — Pagination
+
+**Steps**
+1. Seed > 20 events (the default per_page). 
+2. On Audit Logs, confirm the pager appears and **Next**/**Previous** work; the
+   "Page X / Y" indicator updates and buttons disable at the ends.
+
+---
+
+## Logged-in Users page
+
+## TC-S17 — Page loads with active sessions
+
+**Steps**
+1. Ensure at least one user is logged in (the admin running the test counts).
+2. `navigate` to the Logged-in Users URL. Screenshot.
+
+**Expected**
+- Toolbar: Search users, Role filter, **Refresh**, **Force logout everyone**.
+- A table with columns: checkbox, User (avatar + name + email), Role, Logged in
+  (relative), Expires (relative, "in …"), Sessions count, and a **Log out** action.
+- The current admin's row shows a **You** badge.
+
+## TC-S18 — Empty state
+
+**Steps**
+1. If feasible on a throwaway site, clear all sessions
+   (`wp eval 'foreach(get_users() as $u){ WP_Session_Tokens::get_instance($u->ID)->destroy_all(); }'`)
+   — **note:** this logs you out too; only do this when you can log back in.
+
+**Expected**
+- "No users currently have active sessions." and **Force logout everyone** is
+  disabled.
+
+## TC-S19 — Role filter & search
+
+**Steps**
+1. Set the Role filter to a specific role; type part of a name/email in Search.
+
+**Expected**
+- The list narrows accordingly (server-side). "All roles" + empty search restores.
+
+## TC-S20 — Expand multi-session user
+
+**Steps**
+1. Log the same user in from a second browser/profile so `session_count` > 1.
+2. On that user's row click **Show**.
+
+**Expected**
+- Detail rows expand showing per-session Browser / OS, IP, and an **End** action.
+- The session matching the current device shows a **This device** badge.
+
+## TC-S21 — Force logout one user (modal)
+
+**Steps**
+1. On a **non-self** user's row click **Log out**. A `<Modal>` "Log out this user?"
+   appears.
+2. Confirm with **Force logout**.
+
+**Expected**
+- Modal message names the user; confirming ends that user's sessions and the row
+  drops out (or session count goes to 0) after refresh.
+- A `forced_logout` row is recorded in the audit log (verify on Audit Logs page if
+  logging is on).
+- ⚠️ Do **not** test "Log out" on your own (You) row unless you intend to be
+  logged out — the modal warns "you will be logged out immediately."
+
+## TC-S22 — Bulk force logout with "Keep me logged in"
+
+**Steps**
+1. Tick the checkboxes for two non-self users (the bulk bar shows "N selected").
+2. Click **Force logout selected** → modal. Leave **Keep me logged in** checked.
+3. Confirm.
+
+**Expected**
+- Selected users' sessions end; the admin's own session is preserved (excludeSelf
+  defaults to checked). Selection clears after the action.
+
+## TC-S23 — Force logout everyone (excludeSelf)
+
+**Steps**
+1. Click **Force logout everyone** → modal "Force logout everyone?".
+2. Keep **Keep me logged in** checked; confirm.
+
+**Expected**
+- All other users' sessions are destroyed; the current admin stays logged in (the
+  page does not bounce to wp-login). Unchecking "Keep me logged in" would also end
+  the admin's session — only do that intentionally.
+
+---
+
+## Extensibility (no-op without Pro)
+
+## TC-S24 — Column / row-action filters default cleanly
+
+**Steps**
+1. With no Pro plugin active, load Audit Logs and Logged-in Users.
+
+**Expected**
+- `wplalr_log_columns`, `wplalr_session_columns`, and `wplalr_admin_nav_items` all
+  return defaults (the only nav/column JS filters wired in this branch); the UI is
+  unchanged and no console errors appear. (Row-action seams named in the plan are
+  not implemented here yet.)
+
+---
+
+## Regression checklist (run before merge)
+
+- [ ] `composer phpcs` → 0 errors / 0 warnings.
+- [ ] `npm run lint:js` → exit 0.
+- [ ] `npm run build` → compiles; one `admin/script.*` bundle emitted.
+- [ ] TC-S01 … TC-S16 pass (menu, nav, Others, Audit Logs) with no console errors.
+- [ ] TC-S17 … TC-S23 pass (Logged-in Users) — run destructive cases on a throwaway
+      site or with a second account; never on your own session unintentionally.
+- [ ] TC-S24 passes (filters default; no Pro).

--- a/docs/logged-in-users-plan.md
+++ b/docs/logged-in-users-plan.md
@@ -1,0 +1,235 @@
+# Logged-in Users & Force Logout — Implementation Plan
+
+Status: **Spec / planning** (no code yet). Companion to
+[`audit-logs-plan.md`](audit-logs-plan.md); reuses its `UserAgent` parser, REST
+patterns, and (optionally) writes to its log table.
+
+Goal: a **Sessions** tab listing users with active login sessions in a table, and
+the ability to **force logout** — per session, per user, selected users (bulk),
+or everyone. All **Free**.
+
+This pairs naturally with our Last Login / audit-log differentiators: Last Login
+says *when* someone last logged in; Sessions says *who is logged in right now* and
+lets an admin end those sessions.
+
+---
+
+## 1. Data source — WordPress session tokens
+
+WordPress already persists every active login session. We do **not** invent
+session tracking — we read and act on core's store:
+
+- Sessions live in the `session_tokens` user meta, managed by
+  `WP_Session_Tokens` / `WP_User_Meta_Session_Tokens`. Each entry has
+  `expiration`, `login` (login timestamp), `ip`, and `ua` (user agent).
+- **List active sessions:** the set of users with a non-empty `session_tokens`
+  meta. One efficient query against `usermeta`
+  (`meta_key = 'session_tokens'`), then `WP_Session_Tokens::get_instance( $uid )
+  ->get_all()` per user to expand individual sessions. Filter out expired tokens
+  (expiration < now) — core lazily garbage-collects, so the raw meta can hold
+  stale rows.
+- **Force logout (the supported APIs):**
+  - one session: `WP_Session_Tokens::get_instance( $uid )->destroy( $token )`
+    (we key sessions by a hash/verifier, never expose the raw token).
+  - all sessions for a user: `…->destroy_all()`.
+  - everyone: `WP_Session_Tokens::destroy_all_for_all_users()` (static).
+
+Because this is core's own store, it works with any auth plugin that uses
+standard WP sessions (including our own redirects, WooCommerce, etc.).
+
+---
+
+## 2. Scope
+
+**In scope (Free):**
+- Sessions table: user, role(s), login time, expiration / "expires in", IP,
+  browser/OS, session count, current-session flag.
+- Force logout: single session, whole user, **bulk (selected users)**, and
+  **everyone**.
+- Search (username/email) + role filter + pagination.
+- Safeguards around logging out the **current** admin.
+
+**Out of scope (later / Pro candidates):**
+- Live auto-refresh / real-time presence (v1 is on-demand refresh).
+- Per-session geolocation, concurrent-session limits, "kick on Nth login".
+- Scheduled/automatic idle logout.
+
+---
+
+## 3. PHP architecture (aligned to `includes/`)
+
+Namespace `PluginizeLab\WpLoginLogoutRedirect`, PSR-4 from `includes/`, wired into
+`WpLoginLogoutRedirect::init_classes()`'s `$container`.
+
+### 3.1 `includes/Sessions/SessionRepository.php` (new)
+The only place that reads/acts on session data:
+- `query( array $args ): array` — paginated list of **users with active
+  sessions**. Args: `page`, `per_page`, `search` (user_login/email/display_name),
+  `role`, `orderby`, `order`. Strategy: query distinct `user_id`s from
+  `usermeta` where `meta_key='session_tokens'` (with `LIMIT`/`OFFSET` for
+  pagination and a `COUNT` for totals), then hydrate each via `get_userdata` +
+  `WP_Session_Tokens::get_instance()->get_all()`. Returns
+  `[ 'items' => [...], 'total' => int, 'pages' => int ]`, each item carrying the
+  user summary + its (non-expired) sessions (each with a stable
+  `token_id` = hash of the verifier, `login`, `expiration`, `ip`, `ua`, parsed
+  `browser`/`device_os` via the audit-log `UserAgent` parser, and
+  `is_current` for the requesting admin's own session).
+- `destroy_session( int $user_id, string $token_id ): bool`
+- `destroy_user( int $user_id ): bool` — `destroy_all()` for one user.
+- `destroy_users( int[] $user_ids ): int` — bulk; returns affected count.
+- `destroy_all( int[] $exclude = [] ): int` — everyone; supports excluding the
+  current admin so they aren't logged out mid-action.
+
+Every destroy fires `do_action( 'wplalr_session_destroyed', $user_id, $context )`
+so the audit logger can record a `forced_logout` row (see §6).
+
+### 3.2 `includes/REST/SessionsController.php` (new)
+`WP_REST_Controller`, namespace `wplalr/v1`, base `sessions`, cap
+`manage_options`, registered alongside the other controllers in
+`WpLoginLogoutRedirect::register_rest_routes()`:
+- `GET    wplalr/v1/sessions` → paginated list (args from §3.1).
+- `DELETE wplalr/v1/sessions/(?P<user>\d+)/(?P<token>[\w]+)` → one session.
+- `DELETE wplalr/v1/sessions/(?P<user>\d+)` → all of one user's sessions.
+- `POST   wplalr/v1/sessions/bulk-destroy` → body `{ user_ids: [], exclude_self }`.
+- `POST   wplalr/v1/sessions/destroy-all` → everyone (honors `exclude_self`).
+
+All write routes: `manage_options` + nonce (cookie auth, like existing
+controllers), input sanitized, user IDs validated against existing users.
+
+### 3.3 Wiring
+- `init_classes()`: add `session_repository`, `sessions_controller`.
+- No DB migration, no new options, no cron — this feature is **stateless**; it
+  reads/acts on core session meta directly. (The only persisted side effect is an
+  optional audit-log row, §6.)
+
+---
+
+## 4. React admin UI (`src/`)
+
+**Delivery: a dedicated submenu page rendered as one view of the shared React
+app** — see [`admin-subpages-plan.md`](admin-subpages-plan.md). A **Logged-in
+Users** submenu under Redirect Options (`admin.php?page=wplalr_sessions`), mount
+node `#wplalr-sessions`. The single `admin/script` bundle is enqueued on this
+screen and its mount-node dispatcher renders `<SessionsApp>` — no separate
+webpack entry/bundle. The enqueue localizes `currentUserId` so the app can
+badge/guard the admin's own session.
+
+- **`<SessionsApp>`** (new view) — mounted on `#wplalr-sessions` by the
+  `src/admin.js` dispatcher, wrapped in the shared `PageShell` (header +
+  cross-page nav). Single view, no internal router.
+- **`src/components/SessionsViewer.js`** (new):
+  - **Toolbar:** search box, role filter `SelectControl`, **Refresh** button,
+    and a **Force logout everyone** button (destructive, behind a confirm
+    `Modal`, with an "exclude me" default-checked option).
+  - **Table:** checkbox column (row select for bulk), user (avatar + name +
+    email), role(s), login time (`human_time_diff`), expires-in, IP, browser/OS,
+    session count, and a per-row actions menu (**Log out this user**; if a user
+    has multiple sessions, an expandable sub-list with **Log out this session**
+    per device). The requesting admin's own row/session is badged **"You"** and
+    its destroy action shows a confirm warning ("this will log you out").
+  - **Bulk bar:** when rows are selected, show "Force logout selected (N)".
+  - **Empty state** when no active sessions.
+- **`src/hooks/useSessions.js`** (new) — `apiFetch` against
+  `/wplalr/v1/sessions` with pagination/search/filter state, plus the destroy
+  mutations; re-fetches after each action. Reuse the `@wordpress/notices`
+  snackbar pattern for confirmations/results.
+- Pro slots via `@wordpress/hooks`: `wplalr_session_columns`,
+  `wplalr_session_row_actions`.
+
+---
+
+## 5. Safeguards & UX
+
+- **Don't silently self-logout.** "Force logout everyone" and bulk actions
+  default to **excluding the current admin**; logging out your own session is
+  possible but always behind an explicit confirm.
+- **Confirm destructive actions** (everyone / bulk / self) with a `Modal`.
+- **Capability + nonce** on every write; bulk/everyone are heavier so consider a
+  modest server-side guard (e.g. cap re-check) and clear result counts.
+- **Pagination + expired-token filtering** so a site with many users/sessions
+  doesn't load everything at once or show stale rows.
+- **No raw tokens client-side** — expose only a non-reversible `token_id`.
+
+---
+
+## 6. Audit-log integration (optional, Free)
+
+If the audit-log feature ([`audit-logs-plan.md`](audit-logs-plan.md)) is present
+and logging is enabled, the `Logger` hooks `wplalr_session_destroyed` and writes a
+row with `event = 'forced_logout'`, `description` noting the actor (admin) and
+scope (self/user/bulk/all). Cleanly degrades — Sessions works with or without the
+logs feature; the two are independent but compose.
+
+---
+
+## 7. Testing / acceptance
+
+- `composer phpcs` + `php -l` clean; `npm run build` + `npm run lint:js` clean.
+- Manual (extend [`browser-test-cases.md`](browser-test-cases.md)):
+  - Log in as two users in two browsers → both appear with correct IP/browser.
+  - Force logout one user → their next request bounces to login; row disappears
+    on refresh.
+  - Multi-session user (two devices) → can kill one device, the other survives.
+  - Bulk select + force logout → all selected ended; counts reported.
+  - "Force logout everyone (exclude me)" → all others ended, admin stays logged
+    in; without exclude → admin is logged out after confirm.
+  - Expired sessions don't show; pagination + search + role filter work.
+  - With audit logs on, a `forced_logout` row is recorded.
+
+---
+
+## 8. File checklist
+
+**New PHP**
+- `includes/Sessions/SessionRepository.php`
+- `includes/REST/SessionsController.php`
+
+**Changed PHP**
+- `includes/WpLoginLogoutRedirect.php` (container wiring + REST registration)
+- `includes/Logs/Logger.php` (optional `wplalr_session_destroyed` listener — only
+  if audit logs land first)
+
+**New React**
+- `src/components/SessionsApp.js` (new view, rendered by the `src/admin.js`
+  dispatcher — no new webpack entry)
+- `src/components/SessionsViewer.js`
+- `src/hooks/useSessions.js`
+
+**Changed build / PHP (see [`admin-subpages-plan.md`](admin-subpages-plan.md))**
+- `webpack.config.js` — none (single entry)
+- `src/admin.js` (register the `#wplalr-sessions` → `<SessionsApp>` mount)
+- `includes/Settings.php` (Logged-in Users submenu + mount node)
+- `includes/Assets.php` (enqueue `admin/script` on the Sessions screen +
+  `currentUserId`)
+
+**Docs**
+- `readme.txt` (feature + changelog)
+- `docs/extensibility.md` (new filters/actions)
+- `docs/browser-test-cases.md` (Sessions cases)
+
+---
+
+## 9. Build order
+
+1. **`SessionRepository`** (list + all destroy variants) against core session
+   tokens — verify via REST/direct calls, no UI.
+2. **`SessionsController`** REST routes + safeguards (self-exclusion, validation).
+3. **React Sessions tab:** table, search/filter/pagination, per-row + bulk +
+   everyone actions, confirms, current-session badging.
+4. **Audit-log `forced_logout` integration** (only if logs feature exists) +
+   docs + extension filters.
+
+---
+
+## 10. Open questions (recommended defaults)
+
+- Default scope of "Force logout everyone": exclude current admin? →
+  **Yes, exclude self by default** (opt-in checkbox to include self).
+- Show one row per **user** (with expandable sessions) or one row per
+  **session/device**? → **Per user, expandable to sessions** (cleaner for the
+  common single-session case; power users expand). 
+- Pagination strategy on large sites: query distinct `user_id`s from `usermeta`
+  vs. scanning all users? → **Distinct `user_id` from `usermeta`** (only users
+  with sessions; far smaller set).
+- Record forced logouts in the audit log? → **Yes when logs are enabled**
+  (`forced_logout` event); no-op otherwise.

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -56,7 +56,9 @@ class Assets {
 	public function enqueue_admin_scripts() {
 		$screen = get_current_screen();
 
-		if ( ! $screen || 'toplevel_page_wplalr_login_logout_redirect' !== $screen->id ) {
+		// One shared bundle drives all three of our screens (Redirects + Rules,
+		// Audit Logs, Logged-in Users); the app mounts the matching view.
+		if ( ! $screen || ! in_array( $screen->id, Settings::get_page_hooks(), true ) ) {
 			return;
 		}
 
@@ -91,9 +93,11 @@ class Assets {
 			'wplalr-admin-page',
 			'wplalrAdmin',
 			array(
-				'homeUrl'  => home_url(),
-				'restRoot' => esc_url_raw( rest_url() ),
-				'roles'    => $roles,
+				'homeUrl'       => home_url(),
+				'adminUrl'      => esc_url_raw( admin_url() ),
+				'restRoot'      => esc_url_raw( rest_url() ),
+				'roles'         => $roles,
+				'currentUserId' => get_current_user_id(),
 			)
 		);
 

--- a/includes/Logs/Installer.php
+++ b/includes/Logs/Installer.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\Logs;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Creates and upgrades the audit-log table and owns the cleanup cron.
+ */
+class Installer {
+
+	/**
+	 * Schema version. Bump when the table definition changes.
+	 *
+	 * @var string
+	 */
+	const DB_VERSION = '1.0.0';
+
+	/**
+	 * Option storing the installed schema version.
+	 *
+	 * @var string
+	 */
+	const DB_VERSION_OPTION = 'wplalr_db_version';
+
+	/**
+	 * Daily cleanup cron hook.
+	 *
+	 * @var string
+	 */
+	const CLEANUP_HOOK = 'wplalr_logs_cleanup';
+
+	/**
+	 * The constructor.
+	 */
+	public function __construct() {
+		// Migrate on upgrades that don't re-run the activation hook.
+		add_action( 'admin_init', array( $this, 'maybe_install' ) );
+		add_action( self::CLEANUP_HOOK, array( $this, 'run_cleanup' ) );
+	}
+
+	/**
+	 * Fully qualified log table name.
+	 *
+	 * @return string
+	 */
+	public static function table_name() {
+		global $wpdb;
+
+		return $wpdb->prefix . 'wplalr_auth_logs';
+	}
+
+	/**
+	 * Install the table when the stored schema version is missing or stale.
+	 *
+	 * @return void
+	 */
+	public function maybe_install() {
+		if ( self::DB_VERSION === get_option( self::DB_VERSION_OPTION ) ) {
+			return;
+		}
+
+		$this->install();
+	}
+
+	/**
+	 * Create/upgrade the table via dbDelta and (re)schedule the cleanup cron.
+	 *
+	 * @return void
+	 */
+	public function install() {
+		global $wpdb;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$table           = self::table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		// dbDelta is whitespace-sensitive: two spaces after PRIMARY KEY, KEY (not INDEX).
+		$sql = "CREATE TABLE {$table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			user_id bigint(20) unsigned DEFAULT NULL,
+			username varchar(192) NOT NULL DEFAULT '',
+			event varchar(20) NOT NULL DEFAULT '',
+			status varchar(20) NOT NULL DEFAULT 'success',
+			redirect_url varchar(255) DEFAULT NULL,
+			rule_id varchar(64) DEFAULT NULL,
+			ip varchar(50) DEFAULT NULL,
+			agent varchar(255) DEFAULT NULL,
+			browser varchar(50) DEFAULT NULL,
+			device_os varchar(50) DEFAULT NULL,
+			error_code varchar(50) DEFAULT '',
+			description tinytext DEFAULT NULL,
+			created_at datetime DEFAULT NULL,
+			PRIMARY KEY  (id),
+			KEY created_at (created_at),
+			KEY user_id (user_id),
+			KEY event (event),
+			KEY ip (ip)
+		) {$charset_collate};";
+
+		dbDelta( $sql );
+
+		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
+
+		$this->schedule_cleanup();
+	}
+
+	/**
+	 * Schedule the daily cleanup event if not already scheduled.
+	 *
+	 * @return void
+	 */
+	public function schedule_cleanup() {
+		if ( ! wp_next_scheduled( self::CLEANUP_HOOK ) ) {
+			wp_schedule_event( time() + DAY_IN_SECONDS, 'daily', self::CLEANUP_HOOK );
+		}
+	}
+
+	/**
+	 * Clear the cleanup event. Called on deactivation.
+	 *
+	 * @return void
+	 */
+	public static function unschedule_cleanup() {
+		$timestamp = wp_next_scheduled( self::CLEANUP_HOOK );
+
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CLEANUP_HOOK );
+		}
+	}
+
+	/**
+	 * Cron handler: prune rows older than the configured retention window.
+	 *
+	 * @return void
+	 */
+	public function run_cleanup() {
+		$days = (int) get_option( 'wplalr_logs_retention_days', 30 );
+
+		if ( $days > 0 ) {
+			( new LogRepository() )->purge_older_than( $days );
+		}
+	}
+}

--- a/includes/Logs/LogRepository.php
+++ b/includes/Logs/LogRepository.php
@@ -27,7 +27,7 @@ class LogRepository {
 	 *
 	 * @var string[]
 	 */
-	const EVENTS = array( 'login', 'logout', 'failed' );
+	const EVENTS = array( 'login', 'logout', 'failed', 'forced_logout' );
 
 	/**
 	 * Insert a log row.

--- a/includes/Logs/LogRepository.php
+++ b/includes/Logs/LogRepository.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\Logs;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data access layer for the audit-log table.
+ *
+ * The only class that issues SQL against the log table. All input is sanitized
+ * here; dynamic identifiers (orderby/order) are allowlisted and values are bound
+ * via $wpdb->prepare. Callers pass/receive plain arrays.
+ */
+class LogRepository {
+
+	/**
+	 * Columns that may be sorted on (allowlist for `orderby`).
+	 *
+	 * @var string[]
+	 */
+	const SORTABLE = array( 'id', 'created_at', 'username', 'event', 'status' );
+
+	/**
+	 * Event/status columns we expose for filtering.
+	 *
+	 * @var string[]
+	 */
+	const EVENTS = array( 'login', 'logout', 'failed' );
+
+	/**
+	 * Insert a log row.
+	 *
+	 * @param array $data Row data keyed by column.
+	 * @return int Inserted row id, or 0 on failure.
+	 */
+	public function insert( array $data ) {
+		global $wpdb;
+
+		$row = array(
+			'user_id'      => isset( $data['user_id'] ) ? absint( $data['user_id'] ) : null,
+			'username'     => isset( $data['username'] ) ? sanitize_text_field( $data['username'] ) : '',
+			'event'        => isset( $data['event'] ) ? sanitize_key( $data['event'] ) : '',
+			'status'       => isset( $data['status'] ) ? sanitize_key( $data['status'] ) : 'success',
+			'redirect_url' => isset( $data['redirect_url'] ) && '' !== $data['redirect_url'] ? esc_url_raw( $data['redirect_url'] ) : null,
+			'rule_id'      => isset( $data['rule_id'] ) && '' !== $data['rule_id'] ? sanitize_text_field( $data['rule_id'] ) : null,
+			'ip'           => isset( $data['ip'] ) ? sanitize_text_field( $data['ip'] ) : null,
+			'agent'        => isset( $data['agent'] ) ? sanitize_text_field( $data['agent'] ) : null,
+			'browser'      => isset( $data['browser'] ) ? sanitize_text_field( $data['browser'] ) : null,
+			'device_os'    => isset( $data['device_os'] ) ? sanitize_text_field( $data['device_os'] ) : null,
+			'error_code'   => isset( $data['error_code'] ) ? sanitize_text_field( $data['error_code'] ) : '',
+			'description'  => isset( $data['description'] ) ? sanitize_text_field( $data['description'] ) : null,
+			// Stored in GMT; prepare_item() converts to a unix timestamp and to site-local for display.
+			'created_at'   => isset( $data['created_at'] ) ? $data['created_at'] : current_time( 'mysql', true ),
+		);
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$inserted = $wpdb->insert( Installer::table_name(), $row );
+
+		return $inserted ? (int) $wpdb->insert_id : 0;
+	}
+
+	/**
+	 * Paginated, filtered query of log rows.
+	 *
+	 * @param array $args page|per_page|event|status|search|orderby|order.
+	 * @return array{items:array, total:int, pages:int}
+	 */
+	public function query( array $args = array() ) {
+		global $wpdb;
+
+		$args = wp_parse_args(
+			$args,
+			array(
+				'page'     => 1,
+				'per_page' => 20,
+				'event'    => '',
+				'status'   => '',
+				'search'   => '',
+				'orderby'  => 'created_at',
+				'order'    => 'DESC',
+			)
+		);
+
+		$page     = max( 1, absint( $args['page'] ) );
+		$per_page = min( 100, max( 1, absint( $args['per_page'] ) ) );
+		$offset   = ( $page - 1 ) * $per_page;
+
+		$orderby = in_array( $args['orderby'], self::SORTABLE, true ) ? $args['orderby'] : 'created_at';
+		$order   = 'ASC' === strtoupper( (string) $args['order'] ) ? 'ASC' : 'DESC';
+
+		list( $where_sql, $where_values ) = $this->build_where( $args );
+
+		$table = Installer::table_name();
+
+		// Total count for pagination.
+		$count_sql = "SELECT COUNT(*) FROM {$table} {$where_sql}";
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$total = (int) ( $where_values ? $wpdb->get_var( $wpdb->prepare( $count_sql, $where_values ) ) : $wpdb->get_var( $count_sql ) );
+
+		// Page of rows. orderby/order are allowlisted above; values bound below.
+		$list_sql      = "SELECT * FROM {$table} {$where_sql} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+		$list_values   = array_merge( $where_values, array( $per_page, $offset ) );
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$rows = $wpdb->get_results( $wpdb->prepare( $list_sql, $list_values ), ARRAY_A );
+
+		return array(
+			'items' => array_map( array( $this, 'prepare_item' ), (array) $rows ),
+			'total' => $total,
+			'pages' => (int) ceil( $total / $per_page ),
+		);
+	}
+
+	/**
+	 * Build the WHERE clause + bound values from query args.
+	 *
+	 * @param array $args Query args.
+	 * @return array{0:string,1:array} [ where_sql, values ]
+	 */
+	protected function build_where( array $args ) {
+		$clauses = array();
+		$values  = array();
+
+		if ( '' !== $args['event'] && in_array( $args['event'], self::EVENTS, true ) ) {
+			$clauses[] = 'event = %s';
+			$values[]  = $args['event'];
+		}
+
+		if ( '' !== $args['status'] ) {
+			$clauses[] = 'status = %s';
+			$values[]  = sanitize_key( $args['status'] );
+		}
+
+		if ( '' !== $args['search'] ) {
+			global $wpdb;
+			$like      = '%' . $wpdb->esc_like( sanitize_text_field( $args['search'] ) ) . '%';
+			$clauses[] = '( username LIKE %s OR ip LIKE %s )';
+			$values[]  = $like;
+			$values[]  = $like;
+		}
+
+		$where_sql = $clauses ? 'WHERE ' . implode( ' AND ', $clauses ) : '';
+
+		return array( $where_sql, $values );
+	}
+
+	/**
+	 * Normalize a raw DB row for API output.
+	 *
+	 * @param array $row Raw row.
+	 * @return array
+	 */
+	protected function prepare_item( $row ) {
+		// created_at is stored in GMT; PHP's timezone is UTC under WP, so this
+		// yields the correct epoch. Display is converted to the site timezone.
+		$timestamp = ! empty( $row['created_at'] ) ? (int) mysql2date( 'U', $row['created_at'] ) : 0;
+
+		$item = array(
+			'id'           => (int) $row['id'],
+			'user_id'      => $row['user_id'] ? (int) $row['user_id'] : 0,
+			'username'     => (string) $row['username'],
+			'event'        => (string) $row['event'],
+			'status'       => (string) $row['status'],
+			'redirect_url' => (string) $row['redirect_url'],
+			'rule_id'      => (string) $row['rule_id'],
+			'ip'           => (string) $row['ip'],
+			'browser'      => (string) $row['browser'],
+			'device_os'    => (string) $row['device_os'],
+			'error_code'   => (string) $row['error_code'],
+			'created_at'   => $timestamp ? wp_date( 'Y-m-d H:i:s', $timestamp ) : '',
+			'time_diff'    => $timestamp ? sprintf(
+				/* translators: %s: human-readable time difference, e.g. "5 mins". */
+				__( '%s ago', 'wp-login-logout-redirect' ),
+				human_time_diff( $timestamp )
+			) : '',
+		);
+
+		/**
+		 * Filter a single log row before it is returned by the REST API.
+		 *
+		 * @param array $item The prepared row.
+		 * @param array $row  The raw DB row.
+		 */
+		return apply_filters( 'wplalr_rest_log_item', $item, $row );
+	}
+
+	/**
+	 * Delete a single row.
+	 *
+	 * @param int $id Row id.
+	 * @return bool
+	 */
+	public function delete( $id ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (bool) $wpdb->delete( Installer::table_name(), array( 'id' => absint( $id ) ), array( '%d' ) );
+	}
+
+	/**
+	 * Delete every row (TRUNCATE).
+	 *
+	 * @return void
+	 */
+	public function delete_all() {
+		global $wpdb;
+
+		$table = Installer::table_name();
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( "TRUNCATE TABLE {$table}" );
+	}
+
+	/**
+	 * Delete rows older than N days.
+	 *
+	 * @param int $days Retention window in days.
+	 * @return int Rows deleted.
+	 */
+	public function purge_older_than( $days ) {
+		global $wpdb;
+
+		$days = absint( $days );
+
+		if ( $days < 1 ) {
+			return 0;
+		}
+
+		$table  = Installer::table_name();
+		$cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $days * DAY_IN_SECONDS ) );
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->query( $wpdb->prepare( "DELETE FROM {$table} WHERE created_at < %s", $cutoff ) );
+	}
+
+	/**
+	 * Grouped counts by event for the dashboard cards.
+	 *
+	 * @param int $days Window in days (0 = all time).
+	 * @return array{login:int, logout:int, failed:int, total:int}
+	 */
+	public function stats( $days = 0 ) {
+		global $wpdb;
+
+		$days  = absint( $days );
+		$table = Installer::table_name();
+
+		if ( $days > 0 ) {
+			$cutoff = gmdate( 'Y-m-d H:i:s', time() - ( $days * DAY_IN_SECONDS ) );
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$rows = $wpdb->get_results( $wpdb->prepare( "SELECT event, COUNT(*) AS total FROM {$table} WHERE created_at >= %s GROUP BY event", $cutoff ), ARRAY_A );
+		} else {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
+			$rows = $wpdb->get_results( "SELECT event, COUNT(*) AS total FROM {$table} GROUP BY event", ARRAY_A );
+		}
+
+		$stats = array(
+			'login'  => 0,
+			'logout' => 0,
+			'failed' => 0,
+			'total'  => 0,
+		);
+
+		foreach ( (array) $rows as $row ) {
+			$event = isset( $row['event'] ) ? $row['event'] : '';
+			$count = isset( $row['total'] ) ? (int) $row['total'] : 0;
+
+			if ( isset( $stats[ $event ] ) ) {
+				$stats[ $event ] = $count;
+			}
+
+			$stats['total'] += $count;
+		}
+
+		return $stats;
+	}
+}

--- a/includes/Logs/Logger.php
+++ b/includes/Logs/Logger.php
@@ -50,6 +50,7 @@ class Logger {
 		add_action( 'wplalr_after_resolve', array( $this, 'on_after_resolve' ), 10, 4 );
 		add_action( 'wp_login_failed', array( $this, 'on_login_failed' ), 10, 2 );
 		add_action( 'shutdown', array( $this, 'flush_pending_login' ) );
+		add_action( 'wplalr_session_destroyed', array( $this, 'on_session_destroyed' ), 10, 2 );
 	}
 
 	/**
@@ -140,6 +141,36 @@ class Logger {
 					'event'      => 'failed',
 					'status'     => 'failed',
 					'error_code' => $error_code,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Record a forced logout performed from the Logged-in Users screen.
+	 *
+	 * @param int    $user_id The user whose session(s) were destroyed.
+	 * @param string $context Scope: session|user|bulk|all.
+	 * @return void
+	 */
+	public function on_session_destroyed( $user_id, $context = '' ) {
+		$user  = get_userdata( $user_id );
+		$actor = wp_get_current_user();
+
+		$this->record(
+			array_merge(
+				$this->base_row(),
+				array(
+					'user_id'     => $user_id,
+					'username'    => $user instanceof \WP_User ? $user->user_login : '',
+					'event'       => 'forced_logout',
+					'status'      => 'success',
+					'description' => sprintf(
+						/* translators: 1: admin username, 2: scope (session/user/bulk/all). */
+						__( 'Forced logout by %1$s (%2$s)', 'wp-login-logout-redirect' ),
+						$actor instanceof \WP_User && $actor->exists() ? $actor->user_login : __( 'system', 'wp-login-logout-redirect' ),
+						$context
+					),
 				)
 			)
 		);

--- a/includes/Logs/Logger.php
+++ b/includes/Logs/Logger.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\Logs;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Records login / logout / failed-login events to the audit-log table.
+ *
+ * Gated behind the `wplalr_enable_logs` option (off by default) so no PII is
+ * collected unless an admin opts in.
+ *
+ * Redirect capture: `wp_login` fires before WordPress resolves the login
+ * redirect, so a login is parked as "pending" on `wp_login` and flushed (with
+ * the resolved URL + matched rule id) from `wplalr_after_resolve`. A `shutdown`
+ * safety net flushes the row even when no redirect was resolved (e.g. a
+ * programmatic login that never hit the `login_redirect` filter).
+ */
+class Logger {
+
+	/**
+	 * Data layer.
+	 *
+	 * @var LogRepository
+	 */
+	protected $repository;
+
+	/**
+	 * Pending login row awaiting redirect enrichment, or null.
+	 *
+	 * @var array|null
+	 */
+	protected $pending_login = null;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param LogRepository $repository Data layer.
+	 */
+	public function __construct( LogRepository $repository ) {
+		$this->repository = $repository;
+
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		add_action( 'wp_login', array( $this, 'on_login' ), 20, 2 );
+		add_action( 'wplalr_after_resolve', array( $this, 'on_after_resolve' ), 10, 4 );
+		add_action( 'wp_login_failed', array( $this, 'on_login_failed' ), 10, 2 );
+		add_action( 'shutdown', array( $this, 'flush_pending_login' ) );
+	}
+
+	/**
+	 * Whether logging is switched on.
+	 *
+	 * @return bool
+	 */
+	protected function is_enabled() {
+		return 'yes' === get_option( 'wplalr_enable_logs', 'no' );
+	}
+
+	/**
+	 * Park a login until its redirect is resolved.
+	 *
+	 * @param string         $user_login The user login name.
+	 * @param \WP_User|mixed $user       The logged-in user.
+	 * @return void
+	 */
+	public function on_login( $user_login, $user = null ) {
+		$user_id = $user instanceof \WP_User ? $user->ID : 0;
+
+		$this->pending_login = array_merge(
+			$this->base_row(),
+			array(
+				'user_id'  => $user_id,
+				'username' => $user_login,
+				'event'    => 'login',
+				'status'   => 'success',
+			)
+		);
+	}
+
+	/**
+	 * Enrich + write the pending login (or write a logout row) once the rule
+	 * engine has resolved a destination.
+	 *
+	 * @param string        $url     Resolved URL (may be empty when no rule matched).
+	 * @param string        $event   'login' or 'logout'.
+	 * @param \WP_User|null  $user    The user being redirected.
+	 * @param array|null     $matched The matched rule, or null.
+	 * @return void
+	 */
+	public function on_after_resolve( $url, $event, $user = null, $matched = null ) {
+		$rule_id = is_array( $matched ) && ! empty( $matched['id'] ) ? $matched['id'] : '';
+
+		if ( 'login' === $event && null !== $this->pending_login ) {
+			$this->pending_login['redirect_url'] = $url;
+			$this->pending_login['rule_id']      = $rule_id;
+			$this->flush_pending_login();
+
+			return;
+		}
+
+		if ( 'logout' === $event ) {
+			$user_obj = $user instanceof \WP_User ? $user : null;
+
+			$this->record(
+				array_merge(
+					$this->base_row(),
+					array(
+						'user_id'      => $user_obj ? $user_obj->ID : 0,
+						'username'     => $user_obj ? $user_obj->user_login : '',
+						'event'        => 'logout',
+						'status'       => 'success',
+						'redirect_url' => $url,
+						'rule_id'      => $rule_id,
+					)
+				)
+			);
+		}
+	}
+
+	/**
+	 * Record a failed login attempt.
+	 *
+	 * @param string         $username The attempted username.
+	 * @param \WP_Error|null $error    The authentication error, if any.
+	 * @return void
+	 */
+	public function on_login_failed( $username, $error = null ) {
+		$error_code = $error instanceof \WP_Error ? $error->get_error_code() : '';
+
+		$this->record(
+			array_merge(
+				$this->base_row(),
+				array(
+					'username'   => $username,
+					'event'      => 'failed',
+					'status'     => 'failed',
+					'error_code' => $error_code,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Write the parked login row if one is still pending (shutdown safety net
+	 * for logins that never resolved a redirect).
+	 *
+	 * @return void
+	 */
+	public function flush_pending_login() {
+		if ( null === $this->pending_login ) {
+			return;
+		}
+
+		$row                 = $this->pending_login;
+		$this->pending_login = null;
+
+		$this->record( $row );
+	}
+
+	/**
+	 * Insert a row and fire the extension hook.
+	 *
+	 * @param array $data Row data.
+	 * @return void
+	 */
+	protected function record( array $data ) {
+		$row_id = $this->repository->insert( $data );
+
+		if ( $row_id ) {
+			/**
+			 * Fires after an audit-log row is recorded.
+			 *
+			 * The Notifier and Pro enrichment (geo-IP) hook this.
+			 *
+			 * @param int   $row_id The inserted row id.
+			 * @param array $data   The row data.
+			 */
+			do_action( 'wplalr_log_recorded', $row_id, $data );
+		}
+	}
+
+	/**
+	 * Common request context (IP + user agent) for a row.
+	 *
+	 * @return array
+	 */
+	protected function base_row() {
+		$agent  = $this->user_agent();
+		$parsed = UserAgent::parse( $agent );
+
+		return array(
+			'ip'        => $this->client_ip(),
+			'agent'     => $agent,
+			'browser'   => $parsed['browser'],
+			'device_os' => $parsed['device_os'],
+		);
+	}
+
+	/**
+	 * Client IP for the current request.
+	 *
+	 * Uses REMOTE_ADDR only; proxy headers are spoofable, so sites behind a
+	 * trusted proxy can override via the filter.
+	 *
+	 * @return string
+	 */
+	protected function client_ip() {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+
+		/**
+		 * Filter the client IP recorded on a log row.
+		 *
+		 * @param string $ip The IP from REMOTE_ADDR.
+		 */
+		return (string) apply_filters( 'wplalr_log_client_ip', $ip );
+	}
+
+	/**
+	 * User-agent string for the current request.
+	 *
+	 * @return string
+	 */
+	protected function user_agent() {
+		return isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
+	}
+}

--- a/includes/Logs/UserAgent.php
+++ b/includes/Logs/UserAgent.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\Logs;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tiny, dependency-free user-agent parser.
+ *
+ * Extracts a coarse browser name and operating system from a UA string. This is
+ * intentionally compact (a regex map) rather than a full UA database — it covers
+ * the common cases for an audit-log display and degrades to "Unknown".
+ */
+class UserAgent {
+
+	/**
+	 * Parse a user-agent string into browser + OS labels.
+	 *
+	 * @param string $ua Raw user-agent string.
+	 * @return array{browser:string, device_os:string}
+	 */
+	public static function parse( $ua ) {
+		$ua = (string) $ua;
+
+		return array(
+			'browser'   => self::detect_browser( $ua ),
+			'device_os' => self::detect_os( $ua ),
+		);
+	}
+
+	/**
+	 * Detect the browser name. Order matters (e.g. Edge/Opera before Chrome,
+	 * Chrome before Safari) because their UA strings overlap.
+	 *
+	 * @param string $ua User-agent string.
+	 * @return string
+	 */
+	protected static function detect_browser( $ua ) {
+		$map = array(
+			'Edge'              => '/Edg(e|A|iOS)?\//i',
+			'Opera'            => '/OPR\/|Opera/i',
+			'Samsung Internet' => '/SamsungBrowser/i',
+			'Firefox'          => '/Firefox\/|FxiOS/i',
+			'Chrome'           => '/Chrome\/|CriOS/i',
+			'Safari'           => '/Safari\//i',
+			'Internet Explorer' => '/MSIE |Trident\//i',
+		);
+
+		foreach ( $map as $name => $pattern ) {
+			if ( preg_match( $pattern, $ua ) ) {
+				return $name;
+			}
+		}
+
+		return __( 'Unknown', 'wp-login-logout-redirect' );
+	}
+
+	/**
+	 * Detect the operating system.
+	 *
+	 * @param string $ua User-agent string.
+	 * @return string
+	 */
+	protected static function detect_os( $ua ) {
+		$map = array(
+			'Windows'  => '/Windows NT/i',
+			'Android'  => '/Android/i',
+			'iOS'      => '/iPhone|iPad|iPod/i',
+			'macOS'    => '/Macintosh|Mac OS X/i',
+			'Linux'    => '/Linux/i',
+			'Chrome OS' => '/CrOS/i',
+		);
+
+		foreach ( $map as $name => $pattern ) {
+			if ( preg_match( $pattern, $ua ) ) {
+				return $name;
+			}
+		}
+
+		return __( 'Unknown', 'wp-login-logout-redirect' );
+	}
+}

--- a/includes/REST/LogsController.php
+++ b/includes/REST/LogsController.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\REST;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use PluginizeLab\WpLoginLogoutRedirect\Logs\LogRepository;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Audit-log data REST API controller.
+ *
+ * Read + delete endpoints for the log table. The two log *settings*
+ * (`wplalr_enable_logs`, `wplalr_logs_retention_days`) are folded into the main
+ * settings endpoint; this controller serves the log *data*.
+ */
+class LogsController extends WP_REST_Controller {
+
+	/**
+	 * Data layer.
+	 *
+	 * @var LogRepository
+	 */
+	protected $repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param LogRepository|null $repository Data layer.
+	 */
+	public function __construct( $repository = null ) {
+		$this->namespace  = 'wplalr/v1';
+		$this->rest_base  = 'logs';
+		$this->repository = $repository instanceof LogRepository ? $repository : new LogRepository();
+	}
+
+	/**
+	 * Register the routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_all_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/stats',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_stats' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'days' => array(
+							'type'              => 'integer',
+							'default'           => 0,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Capability gate shared by every route.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * GET a paginated, filtered page of log rows.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$args = array(
+			'page'     => $request['page'],
+			'per_page' => $request['per_page'],
+			'event'    => (string) $request['event'],
+			'status'   => (string) $request['status'],
+			'search'   => (string) $request['search'],
+			'orderby'  => (string) $request['orderby'],
+			'order'    => (string) $request['order'],
+		);
+
+		/**
+		 * Filter the log query args before they hit the repository.
+		 *
+		 * @param array            $args    Query args.
+		 * @param \WP_REST_Request $request The request.
+		 */
+		$args = apply_filters( 'wplalr_rest_logs_query_args', $args, $request );
+
+		$result   = $this->repository->query( $args );
+		$response = rest_ensure_response( $result['items'] );
+
+		$response->header( 'X-WP-Total', (int) $result['total'] );
+		$response->header( 'X-WP-TotalPages', (int) $result['pages'] );
+
+		return $response;
+	}
+
+	/**
+	 * GET grouped event counts for the dashboard cards.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_stats( $request ) {
+		return rest_ensure_response( $this->repository->stats( (int) $request['days'] ) );
+	}
+
+	/**
+	 * DELETE a single row.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function delete_item( $request ) {
+		$deleted = $this->repository->delete( (int) $request['id'] );
+
+		return rest_ensure_response( array( 'deleted' => $deleted ) );
+	}
+
+	/**
+	 * DELETE every row.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function delete_all_items( $request ) {
+		$this->repository->delete_all();
+
+		return rest_ensure_response( array( 'deleted' => true ) );
+	}
+
+	/**
+	 * Query params for the list endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'page'     => array(
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'per_page' => array(
+				'type'              => 'integer',
+				'default'           => 20,
+				'sanitize_callback' => 'absint',
+			),
+			'event'    => array(
+				'type'              => 'string',
+				'default'           => '',
+				'enum'              => array( '', 'login', 'logout', 'failed' ),
+				'sanitize_callback' => 'sanitize_key',
+			),
+			'status'   => array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_key',
+			),
+			'search'   => array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'orderby'  => array(
+				'type'              => 'string',
+				'default'           => 'created_at',
+				'enum'              => LogRepository::SORTABLE,
+				'sanitize_callback' => 'sanitize_key',
+			),
+			'order'    => array(
+				'type'              => 'string',
+				'default'           => 'DESC',
+				'enum'              => array( 'ASC', 'DESC', 'asc', 'desc' ),
+			),
+		);
+	}
+}

--- a/includes/REST/LogsController.php
+++ b/includes/REST/LogsController.php
@@ -197,7 +197,7 @@ class LogsController extends WP_REST_Controller {
 			'event'    => array(
 				'type'              => 'string',
 				'default'           => '',
-				'enum'              => array( '', 'login', 'logout', 'failed' ),
+				'enum'              => array( '', 'login', 'logout', 'failed', 'forced_logout' ),
 				'sanitize_callback' => 'sanitize_key',
 			),
 			'status'   => array(

--- a/includes/REST/SessionsController.php
+++ b/includes/REST/SessionsController.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\REST;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use PluginizeLab\WpLoginLogoutRedirect\Sessions\SessionRepository;
+use WP_REST_Controller;
+use WP_REST_Server;
+
+/**
+ * Logged-in users / force-logout REST API controller.
+ */
+class SessionsController extends WP_REST_Controller {
+
+	/**
+	 * Session data layer.
+	 *
+	 * @var SessionRepository
+	 */
+	protected $repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SessionRepository|null $repository Data layer.
+	 */
+	public function __construct( $repository = null ) {
+		$this->namespace  = 'wplalr/v1';
+		$this->rest_base  = 'sessions';
+		$this->repository = $repository instanceof SessionRepository ? $repository : new SessionRepository();
+	}
+
+	/**
+	 * Register the routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/destroy-all',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'destroy_all' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'exclude_self' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/bulk-destroy',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'bulk_destroy' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'user_ids'     => array(
+							'type'     => 'array',
+							'required' => true,
+							'items'    => array( 'type' => 'integer' ),
+						),
+						'exclude_self' => array(
+							'type'    => 'boolean',
+							'default' => true,
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<user>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'destroy_user' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'user' => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<user>\d+)/(?P<token>[A-Za-z0-9]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'destroy_session' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'user'  => array(
+							'type'              => 'integer',
+							'required'          => true,
+							'sanitize_callback' => 'absint',
+						),
+						'token' => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Capability gate shared by every route.
+	 *
+	 * @return bool
+	 */
+	public function permissions_check() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * GET a paginated list of users with active sessions.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$result = $this->repository->query(
+			array(
+				'page'     => $request['page'],
+				'per_page' => $request['per_page'],
+				'search'   => (string) $request['search'],
+				'role'     => (string) $request['role'],
+			)
+		);
+
+		$response = rest_ensure_response( $result['items'] );
+		$response->header( 'X-WP-Total', (int) $result['total'] );
+		$response->header( 'X-WP-TotalPages', (int) $result['pages'] );
+
+		return $response;
+	}
+
+	/**
+	 * DELETE one session of a user.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function destroy_session( $request ) {
+		$destroyed = $this->repository->destroy_session( (int) $request['user'], (string) $request['token'] );
+
+		return rest_ensure_response( array( 'destroyed' => $destroyed ) );
+	}
+
+	/**
+	 * DELETE all of one user's sessions.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function destroy_user( $request ) {
+		$destroyed = $this->repository->destroy_user( (int) $request['user'] );
+
+		return rest_ensure_response( array( 'destroyed' => $destroyed ) );
+	}
+
+	/**
+	 * POST bulk destroy a set of users' sessions.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function bulk_destroy( $request ) {
+		$user_ids = array_map( 'absint', (array) $request['user_ids'] );
+
+		if ( $request['exclude_self'] ) {
+			$user_ids = array_diff( $user_ids, array( get_current_user_id() ) );
+		}
+
+		$affected = $this->repository->destroy_users( $user_ids );
+
+		return rest_ensure_response( array( 'affected' => $affected ) );
+	}
+
+	/**
+	 * POST destroy every user's sessions.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return \WP_REST_Response
+	 */
+	public function destroy_all( $request ) {
+		$exclude = $request['exclude_self'] ? array( get_current_user_id() ) : array();
+
+		$affected = $this->repository->destroy_all( $exclude );
+
+		return rest_ensure_response( array( 'affected' => $affected ) );
+	}
+
+	/**
+	 * Query params for the list endpoint.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		return array(
+			'page'     => array(
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+			'per_page' => array(
+				'type'              => 'integer',
+				'default'           => 20,
+				'sanitize_callback' => 'absint',
+			),
+			'search'   => array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'role'     => array(
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_key',
+			),
+		);
+	}
+}

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -73,9 +73,11 @@ class SettingsController extends WP_REST_Controller {
 	 */
 	public function get_settings( $request ) {
 		$settings = array(
-			'wplalr_login_redirect'  => get_option( 'wplalr_login_redirect', '' ),
-			'wplalr_logout_redirect' => get_option( 'wplalr_logout_redirect', '' ),
-			'rules'                  => array_values( (array) get_option( RuleEngine::OPTION_RULES, array() ) ),
+			'wplalr_login_redirect'      => get_option( 'wplalr_login_redirect', '' ),
+			'wplalr_logout_redirect'     => get_option( 'wplalr_logout_redirect', '' ),
+			'rules'                      => array_values( (array) get_option( RuleEngine::OPTION_RULES, array() ) ),
+			'wplalr_enable_logs'         => 'yes' === get_option( 'wplalr_enable_logs', 'no' ),
+			'wplalr_logs_retention_days' => (int) get_option( 'wplalr_logs_retention_days', 30 ),
 		);
 
 		/**
@@ -107,6 +109,14 @@ class SettingsController extends WP_REST_Controller {
 
 		if ( $request->has_param( 'rules' ) ) {
 			update_option( RuleEngine::OPTION_RULES, $this->sanitize_rules( $request->get_param( 'rules' ) ) );
+		}
+
+		if ( $request->has_param( 'wplalr_enable_logs' ) ) {
+			update_option( 'wplalr_enable_logs', $request->get_param( 'wplalr_enable_logs' ) ? 'yes' : 'no' );
+		}
+
+		if ( $request->has_param( 'wplalr_logs_retention_days' ) ) {
+			update_option( 'wplalr_logs_retention_days', absint( $request->get_param( 'wplalr_logs_retention_days' ) ) );
 		}
 
 		return $this->get_settings( $request );
@@ -378,6 +388,16 @@ class SettingsController extends WP_REST_Controller {
 					'type'        => 'array',
 					'context'     => array( 'view', 'edit' ),
 					'items'       => $this->get_rule_schema(),
+				),
+				'wplalr_enable_logs'         => array(
+					'description' => __( 'Whether login/logout audit logging is enabled.', 'wp-login-logout-redirect' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'wplalr_logs_retention_days' => array(
+					'description' => __( 'Auto-delete log rows older than this many days (0 = keep forever).', 'wp-login-logout-redirect' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
 				),
 			),
 		);

--- a/includes/Sessions/SessionRepository.php
+++ b/includes/Sessions/SessionRepository.php
@@ -1,0 +1,321 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect\Sessions;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use PluginizeLab\WpLoginLogoutRedirect\Logs\UserAgent;
+use WP_Session_Tokens;
+use WP_User_Query;
+
+/**
+ * Reads and acts on WordPress's own login-session store.
+ *
+ * The only class that touches session tokens. It does not invent session
+ * tracking: it lists users with a non-empty `session_tokens` meta and expands
+ * each via WP_Session_Tokens, and destroys sessions through the supported core
+ * APIs. Sessions are keyed to the client by a non-reversible token_id (a hash of
+ * the verifier), never the raw token.
+ */
+class SessionRepository {
+
+	/**
+	 * Paginated list of users with active sessions.
+	 *
+	 * @param array $args page|per_page|search|role.
+	 * @return array{items:array, total:int, pages:int}
+	 */
+	public function query( array $args = array() ) {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'page'     => 1,
+				'per_page' => 20,
+				'search'   => '',
+				'role'     => '',
+			)
+		);
+
+		$page     = max( 1, absint( $args['page'] ) );
+		$per_page = min( 100, max( 1, absint( $args['per_page'] ) ) );
+
+		// Only users that have a session_tokens meta row. meta_query keeps the
+		// scanned set to logged-in users rather than the whole user table.
+		$query_args = array(
+			'meta_key'     => 'session_tokens', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			'meta_compare' => 'EXISTS',
+			'number'       => $per_page,
+			'paged'        => $page,
+			'count_total'  => true,
+			'fields'       => 'all',
+			'orderby'      => 'ID',
+			'order'        => 'ASC',
+		);
+
+		if ( '' !== $args['search'] ) {
+			$query_args['search']         = '*' . sanitize_text_field( $args['search'] ) . '*';
+			$query_args['search_columns'] = array( 'user_login', 'user_email', 'display_name' );
+		}
+
+		if ( '' !== $args['role'] ) {
+			$query_args['role'] = sanitize_key( $args['role'] );
+		}
+
+		$user_query = new WP_User_Query( $query_args );
+		$users      = (array) $user_query->get_results();
+		$total      = (int) $user_query->get_total();
+
+		$current_token = $this->current_token_id();
+
+		$items = array();
+		foreach ( $users as $user ) {
+			$sessions = $this->sessions_for_user( $user->ID, $current_token );
+
+			// A user can carry a stale (all-expired) session_tokens meta; skip it.
+			if ( empty( $sessions ) ) {
+				continue;
+			}
+
+			$items[] = array(
+				'user_id'       => (int) $user->ID,
+				'user_login'    => $user->user_login,
+				'display_name'  => $user->display_name,
+				'user_email'    => $user->user_email,
+				'avatar'        => get_avatar_url( $user->ID, array( 'size' => 48 ) ),
+				'roles'         => array_values( (array) $user->roles ),
+				'session_count' => count( $sessions ),
+				'sessions'      => $sessions,
+			);
+		}
+
+		return array(
+			'items' => $items,
+			'total' => $total,
+			'pages' => (int) ceil( $total / $per_page ),
+		);
+	}
+
+	/**
+	 * Expand a single user's non-expired sessions.
+	 *
+	 * @param int    $user_id       User id.
+	 * @param string $current_token The requesting admin's own token id, if any.
+	 * @return array
+	 */
+	protected function sessions_for_user( $user_id, $current_token = '' ) {
+		$manager = WP_Session_Tokens::get_instance( $user_id );
+		$now     = time();
+		$out     = array();
+
+		foreach ( $manager->get_all() as $token_data ) {
+			if ( empty( $token_data['expiration'] ) || $token_data['expiration'] < $now ) {
+				continue;
+			}
+
+			$ua     = isset( $token_data['ua'] ) ? (string) $token_data['ua'] : '';
+			$parsed = UserAgent::parse( $ua );
+
+			$token_id = $this->token_id( $user_id, $token_data );
+
+			$out[] = array(
+				'token_id'   => $token_id,
+				'login'      => isset( $token_data['login'] ) ? (int) $token_data['login'] : 0,
+				'expiration' => (int) $token_data['expiration'],
+				'ip'         => isset( $token_data['ip'] ) ? (string) $token_data['ip'] : '',
+				'browser'    => $parsed['browser'],
+				'device_os'  => $parsed['device_os'],
+				'is_current' => '' !== $current_token && hash_equals( $current_token, $token_id ),
+			);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Stable, non-reversible id for a session.
+	 *
+	 * Core stores sessions keyed by the token verifier (a hash) since WP 4.0; we
+	 * hash it again with the user id so the client never receives anything that
+	 * maps back to a usable token. The id is only used to address a session for
+	 * destruction within this repository.
+	 *
+	 * @param int   $user_id    User id.
+	 * @param array $token_data The session array from WP_Session_Tokens::get_all.
+	 * @return string
+	 */
+	protected function token_id( $user_id, $token_data ) {
+		// get_all() drops the verifier key, so derive a stable id from the
+		// session's immutable fields. This is matched the same way on destroy.
+		$seed = $user_id . '|' . ( isset( $token_data['login'] ) ? $token_data['login'] : '' ) . '|' . ( isset( $token_data['expiration'] ) ? $token_data['expiration'] : '' ) . '|' . ( isset( $token_data['ip'] ) ? $token_data['ip'] : '' ) . '|' . ( isset( $token_data['ua'] ) ? $token_data['ua'] : '' );
+
+		return wp_hash( $seed );
+	}
+
+	/**
+	 * The token id of the request's own session, for self-identification.
+	 *
+	 * @return string
+	 */
+	protected function current_token_id() {
+		$user_id = get_current_user_id();
+
+		if ( ! $user_id ) {
+			return '';
+		}
+
+		$token = wp_get_session_token();
+
+		if ( ! $token ) {
+			return '';
+		}
+
+		$manager = WP_Session_Tokens::get_instance( $user_id );
+		$session = $manager->get( $token );
+
+		if ( ! is_array( $session ) ) {
+			return '';
+		}
+
+		return $this->token_id( $user_id, $session );
+	}
+
+	/**
+	 * Destroy one session of a user, addressed by its token_id.
+	 *
+	 * @param int    $user_id  User id.
+	 * @param string $token_id Stable session id from query().
+	 * @return bool Whether a matching session was destroyed.
+	 */
+	public function destroy_session( $user_id, $token_id ) {
+		$user_id  = absint( $user_id );
+		$token_id = (string) $token_id;
+
+		if ( ! $user_id || ! get_userdata( $user_id ) ) {
+			return false;
+		}
+
+		// WP_Session_Tokens only exposes destroy($raw_token) / destroy_others /
+		// destroy_all, and get_all() does not return the raw token. To drop one
+		// specific device we filter the raw session_tokens meta — the same store
+		// core's WP_User_Meta_Session_Tokens reads and writes.
+		$sessions = get_user_meta( $user_id, 'session_tokens', true );
+
+		if ( ! is_array( $sessions ) ) {
+			return false;
+		}
+
+		$found = false;
+		foreach ( $sessions as $verifier => $data ) {
+			if ( hash_equals( $this->token_id( $user_id, $data ), $token_id ) ) {
+				unset( $sessions[ $verifier ] );
+				$found = true;
+			}
+		}
+
+		if ( ! $found ) {
+			return false;
+		}
+
+		if ( empty( $sessions ) ) {
+			delete_user_meta( $user_id, 'session_tokens' );
+		} else {
+			update_user_meta( $user_id, 'session_tokens', $sessions );
+		}
+
+		$this->fire_destroyed( $user_id, 'session' );
+
+		return true;
+	}
+
+	/**
+	 * Destroy all sessions of a single user.
+	 *
+	 * @param int $user_id User id.
+	 * @return bool
+	 */
+	public function destroy_user( $user_id ) {
+		$user_id = absint( $user_id );
+
+		if ( ! $user_id || ! get_userdata( $user_id ) ) {
+			return false;
+		}
+
+		WP_Session_Tokens::get_instance( $user_id )->destroy_all();
+		$this->fire_destroyed( $user_id, 'user' );
+
+		return true;
+	}
+
+	/**
+	 * Destroy all sessions for a set of users (bulk).
+	 *
+	 * @param int[] $user_ids User ids.
+	 * @return int Number of users affected.
+	 */
+	public function destroy_users( array $user_ids ) {
+		$affected = 0;
+
+		foreach ( $user_ids as $user_id ) {
+			if ( $this->destroy_user( $user_id ) ) {
+				++$affected;
+			}
+		}
+
+		return $affected;
+	}
+
+	/**
+	 * Destroy every user's sessions, optionally excluding some users.
+	 *
+	 * @param int[] $exclude User ids to leave logged in (e.g. the current admin).
+	 * @return int Number of users affected.
+	 */
+	public function destroy_all( array $exclude = array() ) {
+		$exclude = array_map( 'absint', $exclude );
+
+		// Only iterate users that actually have sessions.
+		$user_ids = get_users(
+			array(
+				'meta_key'     => 'session_tokens', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_compare' => 'EXISTS',
+				'fields'       => 'ID',
+			)
+		);
+
+		$affected = 0;
+		foreach ( $user_ids as $user_id ) {
+			$user_id = (int) $user_id;
+
+			if ( in_array( $user_id, $exclude, true ) ) {
+				continue;
+			}
+
+			if ( $this->destroy_user( $user_id ) ) {
+				++$affected;
+			}
+		}
+
+		return $affected;
+	}
+
+	/**
+	 * Fire the extension hook after a destroy.
+	 *
+	 * @param int    $user_id User id.
+	 * @param string $context self|session|user|bulk|all.
+	 * @return void
+	 */
+	protected function fire_destroyed( $user_id, $context ) {
+		/**
+		 * Fires after a session (or sessions) is forcibly destroyed.
+		 *
+		 * The audit logger hooks this to record a forced_logout row.
+		 *
+		 * @param int    $user_id The affected user.
+		 * @param string $context Scope: session|user|bulk|all.
+		 */
+		do_action( 'wplalr_session_destroyed', $user_id, $context );
+	}
+}

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -4,18 +4,32 @@ namespace PluginizeLab\WpLoginLogoutRedirect;
 
 class Settings {
 	/**
+	 * Hook suffixes for our admin pages, keyed by view.
+	 *
+	 * Populated on `admin_menu`; read by Assets to enqueue the shared bundle on
+	 * exactly our screens without hardcoding screen-id strings.
+	 *
+	 * @var array
+	 */
+	private static $page_hooks = array();
+
+	/**
 	 * The constructor.
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'login_logout_redirect_menu' ) );
 		add_filter( 'plugin_action_links_' . WP_LOGIN_LOGOUT_REDIRECT_BASENAME, array( $this, 'plugin_action_link' ) );
+		add_filter( 'admin_body_class', array( $this, 'admin_body_class' ) );
 	}
 
 	/**
-	 * Register plugin admin menu
+	 * Register plugin admin menu and submenu pages.
+	 *
+	 * All three pages share one React bundle (see Assets); each renders its own
+	 * mount node and the app boots the matching view.
 	 */
 	public function login_logout_redirect_menu() {
-		add_menu_page(
+		$settings = add_menu_page(
 			__( 'WP Login and Logout Redirect Options', 'wp-login-logout-redirect' ),
 			__( 'Redirect Options', 'wp-login-logout-redirect' ),
 			'manage_options',
@@ -23,13 +37,88 @@ class Settings {
 			array( $this, 'login_logout_redirect_settings_form' ),
 			'dashicons-randomize'
 		);
+
+		// Duplicate the parent as the first submenu so the cleaner label shows.
+		add_submenu_page(
+			'wplalr_login_logout_redirect',
+			__( 'Redirect Options', 'wp-login-logout-redirect' ),
+			__( 'Redirect Options', 'wp-login-logout-redirect' ),
+			'manage_options',
+			'wplalr_login_logout_redirect',
+			array( $this, 'login_logout_redirect_settings_form' )
+		);
+
+		$audit_logs = add_submenu_page(
+			'wplalr_login_logout_redirect',
+			__( 'Audit Logs', 'wp-login-logout-redirect' ),
+			__( 'Audit Logs', 'wp-login-logout-redirect' ),
+			'manage_options',
+			'wplalr_audit_logs',
+			array( $this, 'render_audit_logs_page' )
+		);
+
+		$sessions = add_submenu_page(
+			'wplalr_login_logout_redirect',
+			__( 'Logged-in Users', 'wp-login-logout-redirect' ),
+			__( 'Logged-in Users', 'wp-login-logout-redirect' ),
+			'manage_options',
+			'wplalr_sessions',
+			array( $this, 'render_sessions_page' )
+		);
+
+		self::$page_hooks = array(
+			'settings'   => $settings,
+			'audit_logs' => $audit_logs,
+			'sessions'   => $sessions,
+		);
 	}
 
 	/**
-	 * Render the React settings app mount point.
+	 * Get the captured hook suffixes for our admin pages.
+	 *
+	 * @return array Keyed by view: settings|audit_logs|sessions.
+	 */
+	public static function get_page_hooks() {
+		return self::$page_hooks;
+	}
+
+	/**
+	 * Add a shared body class on our admin screens so CSS can target all of
+	 * them (the per-screen body classes differ between the top-level and
+	 * submenu pages).
+	 *
+	 * @param string $classes Space-separated body classes.
+	 * @return string
+	 */
+	public function admin_body_class( $classes ) {
+		$screen = get_current_screen();
+
+		if ( $screen && in_array( $screen->id, self::$page_hooks, true ) ) {
+			$classes .= ' wplalr-admin-page';
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Render the Redirects + Rules app mount point.
 	 */
 	public function login_logout_redirect_settings_form() {
 		echo '<div id="wplalr-settings"></div>';
+	}
+
+	/**
+	 * Render the Audit Logs app mount point.
+	 */
+	public function render_audit_logs_page() {
+		echo '<div id="wplalr-audit-logs"></div>';
+	}
+
+	/**
+	 * Render the Logged-in Users app mount point.
+	 */
+	public function render_sessions_page() {
+		echo '<div id="wplalr-sessions"></div>';
 	}
 
 	/**

--- a/includes/WpLoginLogoutRedirect.php
+++ b/includes/WpLoginLogoutRedirect.php
@@ -86,7 +86,8 @@ final class WpLoginLogoutRedirect {
      * Nothing is being called here yet.
      */
     public function activate() {
-        // Rewrite rules during wp_login_logout_redirect activation
+        // Create the audit-log table and schedule its cleanup cron.
+        ( new Logs\Installer() )->install();
     }
 
     /**
@@ -104,7 +105,10 @@ final class WpLoginLogoutRedirect {
      *
      * Nothing being called here yet.
      */
-    public function deactivate() {     }
+    public function deactivate() {
+        // Clear scheduled cron events; the table and its data are kept.
+        Logs\Installer::unschedule_cleanup();
+    }
 
     /**
      * Define all constants
@@ -174,10 +178,16 @@ final class WpLoginLogoutRedirect {
         $this->container['scripts'] = new Assets();
         $this->container['admin_settings'] = new Settings();
         $this->container['admin_settings_controller'] = new REST\SettingsController();
+        $this->container['logs_controller'] = new REST\LogsController();
         $this->container['rule_engine'] = new RuleEngine();
         $this->container['placeholders'] = new Placeholders();
         $this->container['redirection'] = new Redirection( $this->container['rule_engine'], $this->container['placeholders'] );
         $this->container['user_login_time'] = new UserLoginTime();
+
+        // Audit logs.
+        $this->container['logs_installer']  = new Logs\Installer();
+        $this->container['logs_repository'] = new Logs\LogRepository();
+        $this->container['logger']          = new Logs\Logger( $this->container['logs_repository'] );
     }
 
     /**
@@ -190,6 +200,11 @@ final class WpLoginLogoutRedirect {
             $this->container['admin_settings_controller'] = new REST\SettingsController();
         }
         $this->container['admin_settings_controller']->register_routes();
+
+        if ( ! isset( $this->container['logs_controller'] ) ) {
+            $this->container['logs_controller'] = new REST\LogsController();
+        }
+        $this->container['logs_controller']->register_routes();
     }
 
     /**

--- a/includes/WpLoginLogoutRedirect.php
+++ b/includes/WpLoginLogoutRedirect.php
@@ -179,6 +179,7 @@ final class WpLoginLogoutRedirect {
         $this->container['admin_settings'] = new Settings();
         $this->container['admin_settings_controller'] = new REST\SettingsController();
         $this->container['logs_controller'] = new REST\LogsController();
+        $this->container['sessions_controller'] = new REST\SessionsController();
         $this->container['rule_engine'] = new RuleEngine();
         $this->container['placeholders'] = new Placeholders();
         $this->container['redirection'] = new Redirection( $this->container['rule_engine'], $this->container['placeholders'] );
@@ -205,6 +206,11 @@ final class WpLoginLogoutRedirect {
             $this->container['logs_controller'] = new REST\LogsController();
         }
         $this->container['logs_controller']->register_routes();
+
+        if ( ! isset( $this->container['sessions_controller'] ) ) {
+            $this->container['sessions_controller'] = new REST\SessionsController();
+        }
+        $this->container['sessions_controller']->register_routes();
     }
 
     /**

--- a/src/admin.js
+++ b/src/admin.js
@@ -4,55 +4,48 @@
 import { createRoot } from '@wordpress/element';
 
 /**
- * External dependencies
- */
-import { HashRouter as Router, Routes, Route } from 'react-router-dom';
-
-/**
- * WordPress dependencies
- */
-import { applyFilters } from '@wordpress/hooks';
-
-/**
  * Internal dependencies
  */
 import './components/LayoutStyles.css';
-import { SettingsProvider } from './context/SettingsContext';
-import Layout from './components/Layout';
-import RedirectSettings from './components/RedirectSettings';
-import RulesSettings from './components/RulesSettings';
+import PageShell from './shared/PageShell';
+import SettingsApp from './views/SettingsApp';
+import AuditLogsApp from './views/AuditLogsApp';
+import SessionsApp from './views/SessionsApp';
 
-const App = () => {
-	// Pro extensions add routes here via the `wplalr_routes` filter.
-	const routes = applyFilters( 'wplalr_routes', [
-		{ path: 'rules', element: <RulesSettings /> },
-	] );
-
-	return (
-		<SettingsProvider>
-			<Router>
-				<Routes>
-					<Route path="/" element={ <Layout /> }>
-						<Route index element={ <RedirectSettings /> } />
-						{ routes.map( ( { path, element } ) => (
-							<Route
-								key={ path }
-								path={ path }
-								element={ element }
-							/>
-						) ) }
-					</Route>
-				</Routes>
-			</Router>
-		</SettingsProvider>
-	);
-};
+/**
+ * Each WordPress submenu page renders exactly one of these mount nodes. The
+ * single bundle is enqueued on all three screens; on boot we render whichever
+ * view's node is present, wrapped in the shared PageShell.
+ */
+const VIEWS = [
+	{
+		id: 'wplalr-settings',
+		page: 'wplalr_login_logout_redirect',
+		Component: SettingsApp,
+	},
+	{
+		id: 'wplalr-audit-logs',
+		page: 'wplalr_audit_logs',
+		Component: AuditLogsApp,
+	},
+	{
+		id: 'wplalr-sessions',
+		page: 'wplalr_sessions',
+		Component: SessionsApp,
+	},
+];
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const container = document.getElementById( 'wplalr-settings' );
+	for ( const { id, page, Component } of VIEWS ) {
+		const container = document.getElementById( id );
 
-	if ( container ) {
-		const root = createRoot( container );
-		root.render( <App /> );
+		if ( container ) {
+			createRoot( container ).render(
+				<PageShell current={ page }>
+					<Component />
+				</PageShell>
+			);
+			break;
+		}
 	}
 } );

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -4,7 +4,7 @@ import { Link, Outlet, useLocation } from 'react-router-dom';
 import { applyFilters } from '@wordpress/hooks';
 
 import { useSettings } from '../context/SettingsContext';
-import { RedirectIcon, RulesIcon } from './icons';
+import { RedirectIcon, RulesIcon, OthersIcon } from './icons';
 
 const TABS = [
 	{
@@ -16,6 +16,11 @@ const TABS = [
 		to: '/rules',
 		icon: RulesIcon,
 		label: __( 'Rules', 'wp-login-logout-redirect' ),
+	},
+	{
+		to: '/others',
+		icon: OthersIcon,
+		label: __( 'Others', 'wp-login-logout-redirect' ),
 	},
 ];
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,19 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	Spinner,
-	Card,
-	CardBody,
-	SnackbarList,
-} from '@wordpress/components';
+import { Spinner, Card, CardBody } from '@wordpress/components';
 import { Link, Outlet, useLocation } from 'react-router-dom';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as noticesStore } from '@wordpress/notices';
 import { applyFilters } from '@wordpress/hooks';
 
 import { useSettings } from '../context/SettingsContext';
-import { RedirectIcon, RulesIcon, Squares2X2Icon } from './icons';
-import SettingsHeader from './SettingsHeader';
+import { RedirectIcon, RulesIcon } from './icons';
 
 const TABS = [
 	{
@@ -30,109 +21,59 @@ const TABS = [
 
 const SKELETON_WIDTHS = [ 120, 90 ];
 
+/**
+ * Inner layout for the Settings view: the Redirects/Rules hash tabs and the
+ * routed sub-view. Page chrome (header, cross-page nav, snackbars) lives in the
+ * shared PageShell that wraps this.
+ */
 const Layout = () => {
 	const { isLoading } = useSettings();
 	const { pathname } = useLocation();
 
-	const notices = useSelect(
-		( select ) => select( noticesStore ).getNotices(),
-		[]
-	);
-	const { removeNotice } = useDispatch( noticesStore );
-	const snackbarNotices = notices.filter(
-		( notice ) => notice.type === 'snackbar'
-	);
-
-	// Pro extensions add tabs / header actions via these filters.
+	// Pro extensions add tabs via the `wplalr_tabs` filter.
 	const tabs = applyFilters( 'wplalr_tabs', TABS );
-	const headerActions = applyFilters(
-		'wplalr_header_actions',
-		<>
-			<Button
-				variant="secondary"
-				href="https://wordpress.org/plugins/wp-login-and-logout-redirect/"
-				target="_blank"
-				rel="noreferrer"
-			>
-				{ __( 'Documentation', 'wp-login-logout-redirect' ) }
-			</Button>
-			<Button
-				variant="primary"
-				href="https://buymeacoffee.com/aiarnob"
-				target="_blank"
-				rel="noreferrer"
-			>
-				{ __( 'Support Me', 'wp-login-logout-redirect' ) }
-			</Button>
-		</>
-	);
+
+	if ( isLoading ) {
+		return (
+			<>
+				<div className="wplalr-hash-nav">
+					{ SKELETON_WIDTHS.map( ( width ) => (
+						<div
+							key={ width }
+							className="wplalr-skeleton-tab"
+							style={ { width: `${ width }px` } }
+						/>
+					) ) }
+				</div>
+				<div className="wplalr-section">
+					<Card>
+						<CardBody className="wplalr-form-section-body">
+							<div className="wplalr-loading">
+								<Spinner />
+							</div>
+						</CardBody>
+					</Card>
+				</div>
+			</>
+		);
+	}
 
 	return (
-		<div className="wplalr-admin-app">
-			<SettingsHeader
-				icon={ Squares2X2Icon }
-				title={ __(
-					'WP Login and Logout Redirect',
-					'wp-login-logout-redirect'
-				) }
-				subTitle={ __(
-					'Configure where users are sent after they log in or log out.',
-					'wp-login-logout-redirect'
-				) }
-				actions={ headerActions }
-			/>
-
-			<main className="wplalr-main-content wplalr-setting-wrapper">
-				<div className="wplalr-content-body">
-					{ isLoading ? (
-						<>
-							<div className="wplalr-hash-nav">
-								{ SKELETON_WIDTHS.map( ( width ) => (
-									<div
-										key={ width }
-										className="wplalr-skeleton-tab"
-										style={ { width: `${ width }px` } }
-									/>
-								) ) }
-							</div>
-							<div className="wplalr-section">
-								<Card>
-									<CardBody className="wplalr-form-section-body">
-										<div className="wplalr-loading">
-											<Spinner />
-										</div>
-									</CardBody>
-								</Card>
-							</div>
-						</>
-					) : (
-						<>
-							<div className="wplalr-hash-nav">
-								{ tabs.map( ( { to, icon: Icon, label } ) => (
-									<Link
-										key={ to }
-										to={ to }
-										className={
-											pathname === to ? 'is-active' : ''
-										}
-									>
-										<Icon />
-										{ label }
-									</Link>
-								) ) }
-							</div>
-							<Outlet />
-						</>
-					) }
-				</div>
-			</main>
-
-			<SnackbarList
-				notices={ snackbarNotices }
-				className="components-editor-notices__snackbar"
-				onRemove={ removeNotice }
-			/>
-		</div>
+		<>
+			<div className="wplalr-hash-nav">
+				{ tabs.map( ( { to, icon: Icon, label } ) => (
+					<Link
+						key={ to }
+						to={ to }
+						className={ pathname === to ? 'is-active' : '' }
+					>
+						<Icon />
+						{ label }
+					</Link>
+				) ) }
+			</div>
+			<Outlet />
+		</>
 	);
 };
 

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -406,6 +406,81 @@
 	color: #646970;
 }
 
+/* ========== Logged-in Users: table ========== */
+.wplalr-sessions-table .wplalr-col-check {
+	width: 32px;
+}
+
+.wplalr-session-user {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.wplalr-session-avatar {
+	width: 32px;
+	height: 32px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.wplalr-session-user strong {
+	display: block;
+	color: #1d2327;
+}
+
+.wplalr-session-email {
+	display: block;
+	font-size: 12px;
+	color: #646970;
+}
+
+.wplalr-you-badge {
+	display: inline-block;
+	margin-left: 6px;
+	padding: 1px 6px;
+	border-radius: 8px;
+	font-size: 11px;
+	font-weight: 500;
+	background: #ecf3ff;
+	color: #2271b1;
+}
+
+.wplalr-expand-sessions {
+	margin-left: 8px;
+	height: auto !important;
+	padding: 0 !important;
+}
+
+.wplalr-session-detail td {
+	background: #f6f7f7;
+	font-size: 12px;
+}
+
+.wplalr-session-device {
+	font-weight: 500;
+	color: #3c434a;
+}
+
+.wplalr-session-ip {
+	margin-left: 12px;
+	color: #646970;
+	font-family: Menlo, Consolas, monaco, monospace;
+}
+
+/* ========== Logged-in Users: bulk bar ========== */
+.wplalr-bulk-bar {
+	width: 800px;
+	background: #fff;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 12px 16px;
+}
+
+.wplalr-modal-actions {
+	margin-top: 16px;
+}
+
 /* ========== Rules: cards ========== */
 .wplalr-rule-card {
 	margin-bottom: 16px;

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -297,6 +297,115 @@
 	margin-inline: auto !important;
 }
 
+/* ========== Audit Logs: stat cards ========== */
+.wplalr-stat-cards {
+	display: grid;
+	grid-template-columns: repeat( 4, 1fr );
+	gap: 16px;
+	width: 800px;
+}
+
+.wplalr-stat-card .components-card__body {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 20px 24px;
+}
+
+.wplalr-stat-value {
+	font-size: 28px;
+	font-weight: 600;
+	color: #1d2327;
+	line-height: 1.2;
+}
+
+.wplalr-stat-label {
+	font-size: 13px;
+	color: #646970;
+}
+
+/* ========== Audit Logs: toolbar ========== */
+.wplalr-logs-toolbar {
+	width: 800px;
+	align-items: flex-end !important;
+	gap: 12px;
+}
+
+/* ========== Audit Logs: table ========== */
+.wplalr-logs-table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 13px;
+}
+
+.wplalr-logs-table th {
+	text-align: left;
+	font-weight: 600;
+	color: #1d2327;
+	padding: 8px 12px;
+	border-bottom: 1px solid #dcdcde;
+	white-space: nowrap;
+}
+
+.wplalr-logs-table td {
+	padding: 10px 12px;
+	border-bottom: 1px solid #f0f0f1;
+	color: #3c434a;
+	vertical-align: middle;
+}
+
+.wplalr-logs-redirect {
+	max-width: 220px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-family: Menlo, Consolas, monaco, monospace;
+	font-size: 12px;
+}
+
+.wplalr-event-badge {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 10px;
+	font-size: 12px;
+	font-weight: 500;
+	background: #edeff0;
+	color: #3c434a;
+}
+
+.wplalr-event-badge.is-failed {
+	background: #fcf0f1;
+	color: #d63638;
+}
+
+.wplalr-error-code {
+	display: block;
+	font-size: 11px;
+	color: #d63638;
+	margin-top: 2px;
+}
+
+.wplalr-admin-app .wplalr-log-delete svg {
+	fill: none;
+	stroke: currentColor;
+	width: 18px;
+	height: 18px;
+}
+
+/* ========== Audit Logs: pagination ========== */
+.wplalr-logs-pagination {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	gap: 12px;
+	margin-top: 16px;
+}
+
+.wplalr-logs-page-info {
+	font-size: 13px;
+	color: #646970;
+}
+
 /* ========== Rules: cards ========== */
 .wplalr-rule-card {
 	margin-bottom: 16px;

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -1,5 +1,5 @@
 /* ========== Admin page padding override ========== */
-.toplevel_page_wplalr_login_logout_redirect div#wpcontent {
+.wplalr-admin-page div#wpcontent {
 	padding-inline-start: 0;
 }
 
@@ -75,6 +75,41 @@
 	width: auto;
 	height: 28px;
 	max-width: 180px;
+}
+
+/* ========== Cross-page navigation (submenu pages) ========== */
+.wplalr-page-nav {
+	display: flex;
+	gap: 8px;
+	background: #fff;
+	border-bottom: 1px solid #dcdcde;
+	padding: 0 40px;
+}
+
+.wplalr-page-nav a {
+	display: inline-flex;
+	align-items: center;
+	text-decoration: none;
+	color: #646970;
+	font-weight: 500;
+	font-size: 14px;
+	padding: 14px 12px;
+	border-bottom: 3px solid transparent;
+	transition: all 0.2s ease;
+}
+
+.wplalr-page-nav a:hover {
+	color: #1d2327;
+}
+
+.wplalr-page-nav a:focus {
+	outline: 0;
+	box-shadow: none;
+}
+
+.wplalr-page-nav a.is-active {
+	color: #5539fd;
+	border-bottom: 3px solid #5539fd;
 }
 
 /* ========== Main content area ========== */

--- a/src/components/LogsViewer.js
+++ b/src/components/LogsViewer.js
@@ -1,0 +1,414 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import {
+	Card,
+	CardBody,
+	Button,
+	Spinner,
+	ToggleControl,
+	SelectControl,
+	SearchControl,
+	Modal,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useLogs } from '../hooks/useLogs';
+import { TrashIcon } from './icons';
+
+const EVENT_OPTIONS = [
+	{ label: __( 'All events', 'wp-login-logout-redirect' ), value: '' },
+	{ label: __( 'Login', 'wp-login-logout-redirect' ), value: 'login' },
+	{ label: __( 'Logout', 'wp-login-logout-redirect' ), value: 'logout' },
+	{
+		label: __( 'Failed login', 'wp-login-logout-redirect' ),
+		value: 'failed',
+	},
+];
+
+const STAT_CARDS = [
+	{ key: 'login', label: __( 'Logins', 'wp-login-logout-redirect' ) },
+	{ key: 'logout', label: __( 'Logouts', 'wp-login-logout-redirect' ) },
+	{
+		key: 'failed',
+		label: __( 'Failed logins', 'wp-login-logout-redirect' ),
+	},
+	{ key: 'total', label: __( 'Total events', 'wp-login-logout-redirect' ) },
+];
+
+const EVENT_LABELS = {
+	login: __( 'Login', 'wp-login-logout-redirect' ),
+	logout: __( 'Logout', 'wp-login-logout-redirect' ),
+	failed: __( 'Failed', 'wp-login-logout-redirect' ),
+};
+
+const LogsViewer = () => {
+	const {
+		items,
+		total,
+		totalPages,
+		stats,
+		isLoading,
+		isSavingSettings,
+		enabled,
+		retentionDays,
+		page,
+		event,
+		search,
+		setPage,
+		setEvent,
+		setSearch,
+		refresh,
+		saveLogSettings,
+		deleteLog,
+		deleteAllLogs,
+	} = useLogs();
+
+	const [ confirmClear, setConfirmClear ] = useState( false );
+
+	// Pro extensions add table columns / row actions via these filters.
+	const columns = applyFilters( 'wplalr_log_columns', null );
+
+	const onClearAll = () => {
+		deleteAllLogs();
+		setConfirmClear( false );
+	};
+
+	const emptyMessage = enabled
+		? __(
+				'No log entries match your filters yet.',
+				'wp-login-logout-redirect'
+		  )
+		: __(
+				'Logging is off. Enable it above to start recording login activity.',
+				'wp-login-logout-redirect'
+		  );
+
+	return (
+		<>
+			{ /* Stat cards */ }
+			<div className="wplalr-section">
+				<div className="wplalr-stat-cards">
+					{ STAT_CARDS.map( ( { key, label } ) => (
+						<Card key={ key } className="wplalr-stat-card">
+							<CardBody>
+								<span className="wplalr-stat-value">
+									{ stats[ key ] ?? 0 }
+								</span>
+								<span className="wplalr-stat-label">
+									{ label }
+								</span>
+							</CardBody>
+						</Card>
+					) ) }
+				</div>
+			</div>
+
+			{ /* Settings: enable + retention */ }
+			<div className="wplalr-section">
+				<Card>
+					<CardBody className="wplalr-form-section-body">
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Enable logging',
+								'wp-login-logout-redirect'
+							) }
+							help={ __(
+								'Record login, logout and failed-login events. IP address and browser are stored.',
+								'wp-login-logout-redirect'
+							) }
+							checked={ enabled }
+							disabled={ isSavingSettings }
+							onChange={ ( value ) =>
+								saveLogSettings( {
+									wplalr_enable_logs: value,
+								} )
+							}
+						/>
+						<SelectControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Delete logs older than',
+								'wp-login-logout-redirect'
+							) }
+							value={ String( retentionDays ) }
+							disabled={ isSavingSettings }
+							options={ [
+								{
+									label: __(
+										'7 days',
+										'wp-login-logout-redirect'
+									),
+									value: '7',
+								},
+								{
+									label: __(
+										'30 days',
+										'wp-login-logout-redirect'
+									),
+									value: '30',
+								},
+								{
+									label: __(
+										'90 days',
+										'wp-login-logout-redirect'
+									),
+									value: '90',
+								},
+								{
+									label: __(
+										'Keep forever',
+										'wp-login-logout-redirect'
+									),
+									value: '0',
+								},
+							] }
+							onChange={ ( value ) =>
+								saveLogSettings( {
+									wplalr_logs_retention_days: parseInt(
+										value,
+										10
+									),
+								} )
+							}
+						/>
+					</CardBody>
+				</Card>
+			</div>
+
+			{ /* Toolbar */ }
+			<div className="wplalr-section">
+				<Flex className="wplalr-logs-toolbar" wrap>
+					<FlexItem isBlock>
+						<SearchControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Search logs',
+								'wp-login-logout-redirect'
+							) }
+							placeholder={ __(
+								'Search username or IP…',
+								'wp-login-logout-redirect'
+							) }
+							value={ search }
+							onChange={ setSearch }
+						/>
+					</FlexItem>
+					<FlexItem>
+						<SelectControl
+							__nextHasNoMarginBottom
+							label={ __( 'Event', 'wp-login-logout-redirect' ) }
+							hideLabelFromVision
+							value={ event }
+							options={ EVENT_OPTIONS }
+							onChange={ setEvent }
+						/>
+					</FlexItem>
+					<FlexItem>
+						<Button variant="secondary" onClick={ refresh }>
+							{ __( 'Refresh', 'wp-login-logout-redirect' ) }
+						</Button>
+					</FlexItem>
+					<FlexItem>
+						<Button
+							variant="secondary"
+							isDestructive
+							onClick={ () => setConfirmClear( true ) }
+							disabled={ total === 0 }
+						>
+							{ __( 'Delete all', 'wp-login-logout-redirect' ) }
+						</Button>
+					</FlexItem>
+				</Flex>
+			</div>
+
+			{ /* Table */ }
+			<div className="wplalr-section">
+				<Card>
+					<CardBody className="wplalr-form-section-body">
+						{ isLoading && (
+							<div className="wplalr-loading">
+								<Spinner />
+							</div>
+						) }
+						{ ! isLoading && items.length === 0 && (
+							<p className="wplalr-section-description">
+								{ emptyMessage }
+							</p>
+						) }
+						{ ! isLoading && items.length > 0 && (
+							<table className="wplalr-logs-table">
+								<thead>
+									<tr>
+										<th>
+											{ __(
+												'Time',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'User',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Event',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'IP',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Browser / OS',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Redirect',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th
+											aria-label={ __(
+												'Actions',
+												'wp-login-logout-redirect'
+											) }
+										/>
+									</tr>
+								</thead>
+								<tbody>
+									{ items.map( ( row ) => (
+										<tr key={ row.id }>
+											<td title={ row.created_at }>
+												{ row.time_diff }
+											</td>
+											<td>{ row.username || '—' }</td>
+											<td>
+												<span
+													className={ `wplalr-event-badge is-${ row.status }` }
+												>
+													{ EVENT_LABELS[
+														row.event
+													] || row.event }
+												</span>
+												{ row.error_code && (
+													<span className="wplalr-error-code">
+														{ row.error_code }
+													</span>
+												) }
+											</td>
+											<td>{ row.ip || '—' }</td>
+											<td>
+												{ row.browser }
+												{ row.device_os
+													? ` / ${ row.device_os }`
+													: '' }
+											</td>
+											<td className="wplalr-logs-redirect">
+												{ row.redirect_url || '—' }
+											</td>
+											<td>
+												<Button
+													size="small"
+													isDestructive
+													className="wplalr-log-delete"
+													icon={ <TrashIcon /> }
+													label={ __(
+														'Delete entry',
+														'wp-login-logout-redirect'
+													) }
+													onClick={ () =>
+														deleteLog( row.id )
+													}
+												/>
+											</td>
+										</tr>
+									) ) }
+								</tbody>
+							</table>
+						) }
+
+						{ columns }
+
+						{ totalPages > 1 && (
+							<div className="wplalr-logs-pagination">
+								<Button
+									variant="secondary"
+									disabled={ page <= 1 }
+									onClick={ () => setPage( page - 1 ) }
+								>
+									{ __(
+										'Previous',
+										'wp-login-logout-redirect'
+									) }
+								</Button>
+								<span className="wplalr-logs-page-info">
+									{ /* translators: 1: current page, 2: total pages. */ }
+									{ __( 'Page', 'wp-login-logout-redirect' ) }{ ' ' }
+									{ page } / { totalPages }
+								</span>
+								<Button
+									variant="secondary"
+									disabled={ page >= totalPages }
+									onClick={ () => setPage( page + 1 ) }
+								>
+									{ __( 'Next', 'wp-login-logout-redirect' ) }
+								</Button>
+							</div>
+						) }
+					</CardBody>
+				</Card>
+			</div>
+
+			{ confirmClear && (
+				<Modal
+					title={ __(
+						'Delete all logs?',
+						'wp-login-logout-redirect'
+					) }
+					onRequestClose={ () => setConfirmClear( false ) }
+				>
+					<p>
+						{ __(
+							'This permanently removes every recorded event. This cannot be undone.',
+							'wp-login-logout-redirect'
+						) }
+					</p>
+					<Flex justify="flex-end">
+						<Button
+							variant="tertiary"
+							onClick={ () => setConfirmClear( false ) }
+						>
+							{ __( 'Cancel', 'wp-login-logout-redirect' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							onClick={ onClearAll }
+						>
+							{ __( 'Delete all', 'wp-login-logout-redirect' ) }
+						</Button>
+					</Flex>
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default LogsViewer;

--- a/src/components/LogsViewer.js
+++ b/src/components/LogsViewer.js
@@ -31,6 +31,10 @@ const EVENT_OPTIONS = [
 		label: __( 'Failed login', 'wp-login-logout-redirect' ),
 		value: 'failed',
 	},
+	{
+		label: __( 'Forced logout', 'wp-login-logout-redirect' ),
+		value: 'forced_logout',
+	},
 ];
 
 const STAT_CARDS = [
@@ -47,6 +51,7 @@ const EVENT_LABELS = {
 	login: __( 'Login', 'wp-login-logout-redirect' ),
 	logout: __( 'Logout', 'wp-login-logout-redirect' ),
 	failed: __( 'Failed', 'wp-login-logout-redirect' ),
+	forced_logout: __( 'Forced logout', 'wp-login-logout-redirect' ),
 };
 
 const LogsViewer = () => {

--- a/src/components/LogsViewer.js
+++ b/src/components/LogsViewer.js
@@ -8,7 +8,6 @@ import {
 	CardBody,
 	Button,
 	Spinner,
-	ToggleControl,
 	SelectControl,
 	SearchControl,
 	Modal,
@@ -61,9 +60,7 @@ const LogsViewer = () => {
 		totalPages,
 		stats,
 		isLoading,
-		isSavingSettings,
 		enabled,
-		retentionDays,
 		page,
 		event,
 		search,
@@ -71,7 +68,6 @@ const LogsViewer = () => {
 		setEvent,
 		setSearch,
 		refresh,
-		saveLogSettings,
 		deleteLog,
 		deleteAllLogs,
 	} = useLogs();
@@ -92,7 +88,7 @@ const LogsViewer = () => {
 				'wp-login-logout-redirect'
 		  )
 		: __(
-				'Logging is off. Enable it above to start recording login activity.',
+				'Logging is off. Enable it on the Others tab under Redirect Options to start recording login activity.',
 				'wp-login-logout-redirect'
 		  );
 
@@ -114,79 +110,6 @@ const LogsViewer = () => {
 						</Card>
 					) ) }
 				</div>
-			</div>
-
-			{ /* Settings: enable + retention */ }
-			<div className="wplalr-section">
-				<Card>
-					<CardBody className="wplalr-form-section-body">
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __(
-								'Enable logging',
-								'wp-login-logout-redirect'
-							) }
-							help={ __(
-								'Record login, logout and failed-login events. IP address and browser are stored.',
-								'wp-login-logout-redirect'
-							) }
-							checked={ enabled }
-							disabled={ isSavingSettings }
-							onChange={ ( value ) =>
-								saveLogSettings( {
-									wplalr_enable_logs: value,
-								} )
-							}
-						/>
-						<SelectControl
-							__nextHasNoMarginBottom
-							label={ __(
-								'Delete logs older than',
-								'wp-login-logout-redirect'
-							) }
-							value={ String( retentionDays ) }
-							disabled={ isSavingSettings }
-							options={ [
-								{
-									label: __(
-										'7 days',
-										'wp-login-logout-redirect'
-									),
-									value: '7',
-								},
-								{
-									label: __(
-										'30 days',
-										'wp-login-logout-redirect'
-									),
-									value: '30',
-								},
-								{
-									label: __(
-										'90 days',
-										'wp-login-logout-redirect'
-									),
-									value: '90',
-								},
-								{
-									label: __(
-										'Keep forever',
-										'wp-login-logout-redirect'
-									),
-									value: '0',
-								},
-							] }
-							onChange={ ( value ) =>
-								saveLogSettings( {
-									wplalr_logs_retention_days: parseInt(
-										value,
-										10
-									),
-								} )
-							}
-						/>
-					</CardBody>
-				</Card>
 			</div>
 
 			{ /* Toolbar */ }

--- a/src/components/OthersSettings.js
+++ b/src/components/OthersSettings.js
@@ -1,0 +1,108 @@
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	Spinner,
+	ToggleControl,
+	SelectControl,
+} from '@wordpress/components';
+
+import { useSettings } from '../context/SettingsContext';
+
+const RETENTION_OPTIONS = [
+	{ label: __( '7 days', 'wp-login-logout-redirect' ), value: '7' },
+	{ label: __( '30 days', 'wp-login-logout-redirect' ), value: '30' },
+	{ label: __( '90 days', 'wp-login-logout-redirect' ), value: '90' },
+	{ label: __( 'Keep forever', 'wp-login-logout-redirect' ), value: '0' },
+];
+
+const OthersSettings = () => {
+	const { settings, isSaving, saveSettings } = useSettings();
+
+	const [ enableLogs, setEnableLogs ] = useState( false );
+	const [ retentionDays, setRetentionDays ] = useState( '30' );
+
+	useEffect( () => {
+		setEnableLogs( !! settings.wplalr_enable_logs );
+		setRetentionDays( String( settings.wplalr_logs_retention_days ?? 30 ) );
+	}, [ settings.wplalr_enable_logs, settings.wplalr_logs_retention_days ] );
+
+	const handleSubmit = ( event ) => {
+		event.preventDefault();
+		saveSettings( {
+			wplalr_enable_logs: enableLogs,
+			wplalr_logs_retention_days: parseInt( retentionDays, 10 ),
+		} );
+	};
+
+	return (
+		<div
+			className="wplalr-section wplalr-section--narrow"
+			id="wplalr-others-settings"
+		>
+			<form onSubmit={ handleSubmit }>
+				<Card className="wplalr-form-header-card">
+					<CardBody className="wplalr-form-section-header">
+						<h3 className="wplalr-section-title">
+							{ __(
+								'Audit Logging',
+								'wp-login-logout-redirect'
+							) }
+						</h3>
+						<p className="wplalr-section-description">
+							{ __(
+								'Record login, logout and failed-login events. Recorded events appear on the Audit Logs page.',
+								'wp-login-logout-redirect'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+				<Card>
+					<CardBody className="wplalr-form-section-body">
+						<div className="wplalr-settings-group">
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __(
+									'Enable logging',
+									'wp-login-logout-redirect'
+								) }
+								help={ __(
+									'When enabled, IP address and browser are stored alongside each event.',
+									'wp-login-logout-redirect'
+								) }
+								checked={ enableLogs }
+								onChange={ setEnableLogs }
+							/>
+						</div>
+						<div className="wplalr-settings-group">
+							<SelectControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __(
+									'Delete logs older than',
+									'wp-login-logout-redirect'
+								) }
+								value={ retentionDays }
+								options={ RETENTION_OPTIONS }
+								onChange={ setRetentionDays }
+							/>
+						</div>
+						<Button
+							variant="primary"
+							type="submit"
+							isBusy={ isSaving }
+							disabled={ isSaving }
+						>
+							{ isSaving && <Spinner /> }
+							{ __( 'Save Changes', 'wp-login-logout-redirect' ) }
+						</Button>
+					</CardBody>
+				</Card>
+			</form>
+		</div>
+	);
+};
+
+export default OthersSettings;

--- a/src/components/SessionsViewer.js
+++ b/src/components/SessionsViewer.js
@@ -1,0 +1,590 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { useState, Fragment } from '@wordpress/element';
+import {
+	Card,
+	CardBody,
+	Button,
+	Spinner,
+	SelectControl,
+	SearchControl,
+	CheckboxControl,
+	Modal,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useSessions } from '../hooks/useSessions';
+
+const ROLES = window.wplalrAdmin?.roles || {};
+const CURRENT_USER_ID = Number( window.wplalrAdmin?.currentUserId || 0 );
+
+const ROLE_OPTIONS = [
+	{ label: __( 'All roles', 'wp-login-logout-redirect' ), value: '' },
+	...Object.entries( ROLES ).map( ( [ value, label ] ) => ( {
+		label,
+		value,
+	} ) ),
+];
+
+/**
+ * Format a unix timestamp as a coarse relative string.
+ *
+ * @param {number}  ts     Target timestamp (seconds).
+ * @param {boolean} future Whether the target is expected in the future.
+ * @return {string} Relative label.
+ */
+const relative = ( ts, future = false ) => {
+	if ( ! ts ) {
+		return '—';
+	}
+
+	const now = Math.floor( Date.now() / 1000 );
+	const diff = Math.abs( future ? ts - now : now - ts );
+
+	const mins = Math.round( diff / 60 );
+	const hours = Math.round( diff / 3600 );
+	const days = Math.round( diff / 86400 );
+
+	let value;
+	if ( diff < 3600 ) {
+		/* translators: %d: number of minutes. */
+		value = sprintf( __( '%d min', 'wp-login-logout-redirect' ), mins );
+	} else if ( diff < 86400 ) {
+		/* translators: %d: number of hours. */
+		value = sprintf( __( '%d hr', 'wp-login-logout-redirect' ), hours );
+	} else {
+		/* translators: %d: number of days. */
+		value = sprintf( __( '%d days', 'wp-login-logout-redirect' ), days );
+	}
+
+	return future
+		? /* translators: %s: a duration like "5 min". */
+		  sprintf( __( 'in %s', 'wp-login-logout-redirect' ), value )
+		: /* translators: %s: a duration like "5 min". */
+		  sprintf( __( '%s ago', 'wp-login-logout-redirect' ), value );
+};
+
+const SessionsViewer = () => {
+	const {
+		items,
+		total,
+		totalPages,
+		isLoading,
+		page,
+		search,
+		role,
+		setPage,
+		setSearch,
+		setRole,
+		refresh,
+		destroySession,
+		destroyUser,
+		destroyBulk,
+		destroyAll,
+	} = useSessions();
+
+	const [ selected, setSelected ] = useState( [] );
+	const [ expanded, setExpanded ] = useState( [] );
+	const [ confirm, setConfirm ] = useState( null );
+	const [ excludeSelf, setExcludeSelf ] = useState( true );
+
+	// Pro extensions add columns / row actions via these filters.
+	const extraColumns = applyFilters( 'wplalr_session_columns', null );
+
+	const toggleSelect = ( userId ) =>
+		setSelected( ( prev ) =>
+			prev.includes( userId )
+				? prev.filter( ( id ) => id !== userId )
+				: [ ...prev, userId ]
+		);
+
+	const toggleExpand = ( userId ) =>
+		setExpanded( ( prev ) =>
+			prev.includes( userId )
+				? prev.filter( ( id ) => id !== userId )
+				: [ ...prev, userId ]
+		);
+
+	const openConfirm = ( config ) => {
+		setExcludeSelf( true );
+		setConfirm( config );
+	};
+
+	const runConfirm = () => {
+		if ( confirm?.action ) {
+			confirm.action();
+		}
+		setConfirm( null );
+	};
+
+	const onLogoutEveryone = () =>
+		openConfirm( {
+			title: __( 'Force logout everyone?', 'wp-login-logout-redirect' ),
+			message: __(
+				'This ends the active sessions of all logged-in users.',
+				'wp-login-logout-redirect'
+			),
+			withExcludeSelf: true,
+			action: () => destroyAll( excludeSelf ),
+		} );
+
+	const onLogoutSelected = () =>
+		openConfirm( {
+			title: __(
+				'Force logout selected users?',
+				'wp-login-logout-redirect'
+			),
+			message: sprintf(
+				/* translators: %d: number of selected users. */
+				__(
+					'This ends the sessions of %d selected user(s).',
+					'wp-login-logout-redirect'
+				),
+				selected.length
+			),
+			withExcludeSelf: true,
+			action: () => {
+				destroyBulk( selected, excludeSelf );
+				setSelected( [] );
+			},
+		} );
+
+	const onLogoutUser = ( row ) => {
+		const isSelf = row.user_id === CURRENT_USER_ID;
+		openConfirm( {
+			title: __( 'Log out this user?', 'wp-login-logout-redirect' ),
+			message: isSelf
+				? __(
+						'This is your own account — you will be logged out immediately.',
+						'wp-login-logout-redirect'
+				  )
+				: sprintf(
+						/* translators: %s: user display name. */
+						__(
+							'This ends all active sessions for %s.',
+							'wp-login-logout-redirect'
+						),
+						row.display_name || row.user_login
+				  ),
+			action: () => destroyUser( row.user_id ),
+		} );
+	};
+
+	const allOnPageSelected =
+		items.length > 0 &&
+		items.every( ( r ) => selected.includes( r.user_id ) );
+
+	const toggleSelectAll = () =>
+		setSelected( allOnPageSelected ? [] : items.map( ( r ) => r.user_id ) );
+
+	return (
+		<>
+			{ /* Toolbar */ }
+			<div className="wplalr-section">
+				<Flex className="wplalr-logs-toolbar" wrap>
+					<FlexItem isBlock>
+						<SearchControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Search users',
+								'wp-login-logout-redirect'
+							) }
+							placeholder={ __(
+								'Search name or email…',
+								'wp-login-logout-redirect'
+							) }
+							value={ search }
+							onChange={ setSearch }
+						/>
+					</FlexItem>
+					<FlexItem>
+						<SelectControl
+							__nextHasNoMarginBottom
+							label={ __( 'Role', 'wp-login-logout-redirect' ) }
+							hideLabelFromVision
+							value={ role }
+							options={ ROLE_OPTIONS }
+							onChange={ setRole }
+						/>
+					</FlexItem>
+					<FlexItem>
+						<Button variant="secondary" onClick={ refresh }>
+							{ __( 'Refresh', 'wp-login-logout-redirect' ) }
+						</Button>
+					</FlexItem>
+					<FlexItem>
+						<Button
+							variant="secondary"
+							isDestructive
+							onClick={ onLogoutEveryone }
+							disabled={ total === 0 }
+						>
+							{ __(
+								'Force logout everyone',
+								'wp-login-logout-redirect'
+							) }
+						</Button>
+					</FlexItem>
+				</Flex>
+			</div>
+
+			{ /* Bulk bar */ }
+			{ selected.length > 0 && (
+				<div className="wplalr-section">
+					<Flex className="wplalr-bulk-bar">
+						<FlexItem>
+							{ sprintf(
+								/* translators: %d: number of selected users. */
+								__( '%d selected', 'wp-login-logout-redirect' ),
+								selected.length
+							) }
+						</FlexItem>
+						<FlexItem>
+							<Button
+								variant="secondary"
+								isDestructive
+								onClick={ onLogoutSelected }
+							>
+								{ __(
+									'Force logout selected',
+									'wp-login-logout-redirect'
+								) }
+							</Button>
+						</FlexItem>
+					</Flex>
+				</div>
+			) }
+
+			{ /* Table */ }
+			<div className="wplalr-section">
+				<Card>
+					<CardBody className="wplalr-form-section-body">
+						{ isLoading && (
+							<div className="wplalr-loading">
+								<Spinner />
+							</div>
+						) }
+						{ ! isLoading && items.length === 0 && (
+							<p className="wplalr-section-description">
+								{ __(
+									'No users currently have active sessions.',
+									'wp-login-logout-redirect'
+								) }
+							</p>
+						) }
+						{ ! isLoading && items.length > 0 && (
+							<table className="wplalr-logs-table wplalr-sessions-table">
+								<thead>
+									<tr>
+										<th className="wplalr-col-check">
+											<CheckboxControl
+												__nextHasNoMarginBottom
+												checked={ allOnPageSelected }
+												onChange={ toggleSelectAll }
+												label=""
+											/>
+										</th>
+										<th>
+											{ __(
+												'User',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Role',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Logged in',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Expires',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th>
+											{ __(
+												'Sessions',
+												'wp-login-logout-redirect'
+											) }
+										</th>
+										<th
+											aria-label={ __(
+												'Actions',
+												'wp-login-logout-redirect'
+											) }
+										/>
+									</tr>
+								</thead>
+								<tbody>
+									{ items.map( ( row ) => {
+										const isSelf =
+											row.user_id === CURRENT_USER_ID;
+										const first = row.sessions[ 0 ] || {};
+										const isExpanded = expanded.includes(
+											row.user_id
+										);
+
+										return (
+											<Fragment key={ row.user_id }>
+												<tr>
+													<td className="wplalr-col-check">
+														<CheckboxControl
+															__nextHasNoMarginBottom
+															checked={ selected.includes(
+																row.user_id
+															) }
+															onChange={ () =>
+																toggleSelect(
+																	row.user_id
+																)
+															}
+															label=""
+														/>
+													</td>
+													<td>
+														<div className="wplalr-session-user">
+															{ row.avatar && (
+																<img
+																	src={
+																		row.avatar
+																	}
+																	alt=""
+																	className="wplalr-session-avatar"
+																/>
+															) }
+															<div>
+																<strong>
+																	{ row.display_name ||
+																		row.user_login }
+																	{ isSelf && (
+																		<span className="wplalr-you-badge">
+																			{ __(
+																				'You',
+																				'wp-login-logout-redirect'
+																			) }
+																		</span>
+																	) }
+																</strong>
+																<span className="wplalr-session-email">
+																	{
+																		row.user_email
+																	}
+																</span>
+															</div>
+														</div>
+													</td>
+													<td>
+														{ row.roles
+															.map(
+																( r ) =>
+																	ROLES[
+																		r
+																	] || r
+															)
+															.join( ', ' ) }
+													</td>
+													<td>
+														{ relative(
+															first.login
+														) }
+													</td>
+													<td>
+														{ relative(
+															first.expiration,
+															true
+														) }
+													</td>
+													<td>
+														{ row.session_count }
+														{ row.session_count >
+															1 && (
+															<Button
+																variant="link"
+																className="wplalr-expand-sessions"
+																onClick={ () =>
+																	toggleExpand(
+																		row.user_id
+																	)
+																}
+															>
+																{ isExpanded
+																	? __(
+																			'Hide',
+																			'wp-login-logout-redirect'
+																	  )
+																	: __(
+																			'Show',
+																			'wp-login-logout-redirect'
+																	  ) }
+															</Button>
+														) }
+													</td>
+													<td>
+														<Button
+															size="small"
+															variant="secondary"
+															isDestructive
+															onClick={ () =>
+																onLogoutUser(
+																	row
+																)
+															}
+														>
+															{ __(
+																'Log out',
+																'wp-login-logout-redirect'
+															) }
+														</Button>
+													</td>
+												</tr>
+												{ isExpanded &&
+													row.sessions.map(
+														( session ) => (
+															<tr
+																key={
+																	session.token_id
+																}
+																className="wplalr-session-detail"
+															>
+																<td />
+																<td
+																	colSpan={
+																		4
+																	}
+																>
+																	<span className="wplalr-session-device">
+																		{
+																			session.browser
+																		}{ ' ' }
+																		/{ ' ' }
+																		{
+																			session.device_os
+																		}
+																		{ session.is_current && (
+																			<span className="wplalr-you-badge">
+																				{ __(
+																					'This device',
+																					'wp-login-logout-redirect'
+																				) }
+																			</span>
+																		) }
+																	</span>
+																	<span className="wplalr-session-ip">
+																		{
+																			session.ip
+																		}
+																	</span>
+																</td>
+																<td />
+																<td>
+																	<Button
+																		size="small"
+																		variant="tertiary"
+																		isDestructive
+																		onClick={ () =>
+																			destroySession(
+																				row.user_id,
+																				session.token_id
+																			)
+																		}
+																	>
+																		{ __(
+																			'End',
+																			'wp-login-logout-redirect'
+																		) }
+																	</Button>
+																</td>
+															</tr>
+														)
+													) }
+											</Fragment>
+										);
+									} ) }
+								</tbody>
+							</table>
+						) }
+
+						{ extraColumns }
+
+						{ totalPages > 1 && (
+							<div className="wplalr-logs-pagination">
+								<Button
+									variant="secondary"
+									disabled={ page <= 1 }
+									onClick={ () => setPage( page - 1 ) }
+								>
+									{ __(
+										'Previous',
+										'wp-login-logout-redirect'
+									) }
+								</Button>
+								<span className="wplalr-logs-page-info">
+									{ __( 'Page', 'wp-login-logout-redirect' ) }{ ' ' }
+									{ page } / { totalPages }
+								</span>
+								<Button
+									variant="secondary"
+									disabled={ page >= totalPages }
+									onClick={ () => setPage( page + 1 ) }
+								>
+									{ __( 'Next', 'wp-login-logout-redirect' ) }
+								</Button>
+							</div>
+						) }
+					</CardBody>
+				</Card>
+			</div>
+
+			{ confirm && (
+				<Modal
+					title={ confirm.title }
+					onRequestClose={ () => setConfirm( null ) }
+				>
+					<p>{ confirm.message }</p>
+					{ confirm.withExcludeSelf && (
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Keep me logged in',
+								'wp-login-logout-redirect'
+							) }
+							checked={ excludeSelf }
+							onChange={ setExcludeSelf }
+						/>
+					) }
+					<Flex justify="flex-end" className="wplalr-modal-actions">
+						<Button
+							variant="tertiary"
+							onClick={ () => setConfirm( null ) }
+						>
+							{ __( 'Cancel', 'wp-login-logout-redirect' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive
+							onClick={ runConfirm }
+						>
+							{ __( 'Force logout', 'wp-login-logout-redirect' ) }
+						</Button>
+					</Flex>
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default SessionsViewer;

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -10,4 +10,5 @@ export {
 	PlusIcon,
 	TrashIcon,
 	ArrowsUpDownIcon as DragHandleIcon,
+	EllipsisHorizontalCircleIcon as OthersIcon,
 } from '@heroicons/react/24/outline';

--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -17,9 +17,9 @@ const EMPTY_STATS = { login: 0, logout: 0, failed: 0, total: 0 };
 /**
  * Data hook for the Audit Logs view.
  *
- * Owns the paginated/filtered log list, the stat cards, the enable/retention
- * settings (folded into /settings), and the delete mutations. Re-fetches the
- * list + stats after each mutation.
+ * Owns the paginated/filtered log list, the stat cards, and the delete
+ * mutations. Reads the logging-enabled flag (managed on the Others settings tab)
+ * to drive the empty state. Re-fetches the list + stats after each mutation.
  *
  * @return {Object} Logs state and actions.
  */
@@ -33,10 +33,7 @@ export const useLogs = () => {
 	const [ stats, setStats ] = useState( EMPTY_STATS );
 
 	const [ isLoading, setIsLoading ] = useState( true );
-	const [ isSavingSettings, setIsSavingSettings ] = useState( false );
-
 	const [ enabled, setEnabled ] = useState( false );
-	const [ retentionDays, setRetentionDays ] = useState( 30 );
 
 	// Query state.
 	const [ page, setPage ] = useState( 1 );
@@ -93,19 +90,16 @@ export const useLogs = () => {
 		}
 	}, [ page, event, search, notifyError ] );
 
-	// Seed enable/retention from /settings once on mount.
+	// Read the logging-enabled flag from /settings once on mount (it is managed
+	// on the Others settings tab) to drive the empty state.
 	useEffect( () => {
 		let cancelled = false;
 
 		apiFetch( { path: SETTINGS_PATH } )
 			.then( ( response ) => {
-				if ( cancelled ) {
-					return;
+				if ( ! cancelled ) {
+					setEnabled( !! response?.wplalr_enable_logs );
 				}
-				setEnabled( !! response?.wplalr_enable_logs );
-				setRetentionDays(
-					Number( response?.wplalr_logs_retention_days ?? 30 )
-				);
 			} )
 			.catch( notifyError );
 
@@ -128,38 +122,6 @@ export const useLogs = () => {
 		fetchLogs();
 		fetchStats();
 	}, [ fetchLogs, fetchStats ] );
-
-	const saveLogSettings = useCallback(
-		async ( next ) => {
-			setIsSavingSettings( true );
-
-			try {
-				const response = await apiFetch( {
-					path: SETTINGS_PATH,
-					method: 'POST',
-					data: next,
-				} );
-
-				setEnabled( !! response?.wplalr_enable_logs );
-				setRetentionDays(
-					Number( response?.wplalr_logs_retention_days ?? 30 )
-				);
-				createSuccessNotice(
-					__( 'Settings saved.', 'wp-login-logout-redirect' ),
-					{
-						type: 'snackbar',
-						id: 'wplalr-logs-settings-saved',
-						isDismissible: false,
-					}
-				);
-			} catch ( err ) {
-				notifyError( err );
-			} finally {
-				setIsSavingSettings( false );
-			}
-		},
-		[ createSuccessNotice, notifyError ]
-	);
 
 	const deleteLog = useCallback(
 		async ( id ) => {
@@ -207,9 +169,7 @@ export const useLogs = () => {
 		totalPages,
 		stats,
 		isLoading,
-		isSavingSettings,
 		enabled,
-		retentionDays,
 		page,
 		event,
 		search,
@@ -217,7 +177,6 @@ export const useLogs = () => {
 		setEvent: updateEvent,
 		setSearch: updateSearch,
 		refresh,
-		saveLogSettings,
 		deleteLog,
 		deleteAllLogs,
 	};

--- a/src/hooks/useLogs.js
+++ b/src/hooks/useLogs.js
@@ -1,0 +1,224 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
+
+const LOGS_PATH = '/wplalr/v1/logs';
+const STATS_PATH = '/wplalr/v1/logs/stats';
+const SETTINGS_PATH = '/wplalr/v1/settings';
+
+const EMPTY_STATS = { login: 0, logout: 0, failed: 0, total: 0 };
+
+/**
+ * Data hook for the Audit Logs view.
+ *
+ * Owns the paginated/filtered log list, the stat cards, the enable/retention
+ * settings (folded into /settings), and the delete mutations. Re-fetches the
+ * list + stats after each mutation.
+ *
+ * @return {Object} Logs state and actions.
+ */
+export const useLogs = () => {
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const [ items, setItems ] = useState( [] );
+	const [ total, setTotal ] = useState( 0 );
+	const [ totalPages, setTotalPages ] = useState( 0 );
+	const [ stats, setStats ] = useState( EMPTY_STATS );
+
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ isSavingSettings, setIsSavingSettings ] = useState( false );
+
+	const [ enabled, setEnabled ] = useState( false );
+	const [ retentionDays, setRetentionDays ] = useState( 30 );
+
+	// Query state.
+	const [ page, setPage ] = useState( 1 );
+	const [ event, setEvent ] = useState( '' );
+	const [ search, setSearch ] = useState( '' );
+
+	const perPage = 20;
+
+	const notifyError = useCallback(
+		( err ) =>
+			createErrorNotice(
+				err?.message ??
+					__( 'Something went wrong.', 'wp-login-logout-redirect' ),
+				{ type: 'snackbar', id: 'wplalr-logs-error' }
+			),
+		[ createErrorNotice ]
+	);
+
+	const fetchStats = useCallback( async () => {
+		try {
+			const response = await apiFetch( { path: STATS_PATH } );
+			setStats( { ...EMPTY_STATS, ...( response ?? {} ) } );
+		} catch ( err ) {
+			notifyError( err );
+		}
+	}, [ notifyError ] );
+
+	const fetchLogs = useCallback( async () => {
+		setIsLoading( true );
+
+		try {
+			const path = addQueryArgs( LOGS_PATH, {
+				page,
+				per_page: perPage,
+				event,
+				search,
+			} );
+
+			// parse: false so we can read pagination headers.
+			const response = await apiFetch( { path, parse: false } );
+			const data = await response.json();
+
+			setItems( Array.isArray( data ) ? data : [] );
+			setTotal(
+				parseInt( response.headers.get( 'X-WP-Total' ) || '0', 10 )
+			);
+			setTotalPages(
+				parseInt( response.headers.get( 'X-WP-TotalPages' ) || '0', 10 )
+			);
+		} catch ( err ) {
+			notifyError( err );
+		} finally {
+			setIsLoading( false );
+		}
+	}, [ page, event, search, notifyError ] );
+
+	// Seed enable/retention from /settings once on mount.
+	useEffect( () => {
+		let cancelled = false;
+
+		apiFetch( { path: SETTINGS_PATH } )
+			.then( ( response ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setEnabled( !! response?.wplalr_enable_logs );
+				setRetentionDays(
+					Number( response?.wplalr_logs_retention_days ?? 30 )
+				);
+			} )
+			.catch( notifyError );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ notifyError ] );
+
+	// Re-fetch the list whenever query state changes.
+	useEffect( () => {
+		fetchLogs();
+	}, [ fetchLogs ] );
+
+	// Stats once on mount.
+	useEffect( () => {
+		fetchStats();
+	}, [ fetchStats ] );
+
+	const refresh = useCallback( () => {
+		fetchLogs();
+		fetchStats();
+	}, [ fetchLogs, fetchStats ] );
+
+	const saveLogSettings = useCallback(
+		async ( next ) => {
+			setIsSavingSettings( true );
+
+			try {
+				const response = await apiFetch( {
+					path: SETTINGS_PATH,
+					method: 'POST',
+					data: next,
+				} );
+
+				setEnabled( !! response?.wplalr_enable_logs );
+				setRetentionDays(
+					Number( response?.wplalr_logs_retention_days ?? 30 )
+				);
+				createSuccessNotice(
+					__( 'Settings saved.', 'wp-login-logout-redirect' ),
+					{
+						type: 'snackbar',
+						id: 'wplalr-logs-settings-saved',
+						isDismissible: false,
+					}
+				);
+			} catch ( err ) {
+				notifyError( err );
+			} finally {
+				setIsSavingSettings( false );
+			}
+		},
+		[ createSuccessNotice, notifyError ]
+	);
+
+	const deleteLog = useCallback(
+		async ( id ) => {
+			try {
+				await apiFetch( {
+					path: `${ LOGS_PATH }/${ id }`,
+					method: 'DELETE',
+				} );
+				refresh();
+			} catch ( err ) {
+				notifyError( err );
+			}
+		},
+		[ refresh, notifyError ]
+	);
+
+	const deleteAllLogs = useCallback( async () => {
+		try {
+			await apiFetch( { path: LOGS_PATH, method: 'DELETE' } );
+			setPage( 1 );
+			refresh();
+			createSuccessNotice(
+				__( 'All logs deleted.', 'wp-login-logout-redirect' ),
+				{ type: 'snackbar', id: 'wplalr-logs-cleared' }
+			);
+		} catch ( err ) {
+			notifyError( err );
+		}
+	}, [ refresh, createSuccessNotice, notifyError ] );
+
+	// Reset to page 1 when a filter changes.
+	const updateEvent = useCallback( ( value ) => {
+		setEvent( value );
+		setPage( 1 );
+	}, [] );
+
+	const updateSearch = useCallback( ( value ) => {
+		setSearch( value );
+		setPage( 1 );
+	}, [] );
+
+	return {
+		items,
+		total,
+		totalPages,
+		stats,
+		isLoading,
+		isSavingSettings,
+		enabled,
+		retentionDays,
+		page,
+		event,
+		search,
+		setPage,
+		setEvent: updateEvent,
+		setSearch: updateSearch,
+		refresh,
+		saveLogSettings,
+		deleteLog,
+		deleteAllLogs,
+	};
+};

--- a/src/hooks/useSessions.js
+++ b/src/hooks/useSessions.js
@@ -1,0 +1,182 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
+
+const SESSIONS_PATH = '/wplalr/v1/sessions';
+
+/**
+ * Data hook for the Logged-in Users view.
+ *
+ * Lists users with active sessions and exposes the destroy mutations (single
+ * session, whole user, bulk, everyone). Re-fetches after each action.
+ *
+ * @return {Object} Sessions state and actions.
+ */
+export const useSessions = () => {
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const [ items, setItems ] = useState( [] );
+	const [ total, setTotal ] = useState( 0 );
+	const [ totalPages, setTotalPages ] = useState( 0 );
+	const [ isLoading, setIsLoading ] = useState( true );
+
+	const [ page, setPage ] = useState( 1 );
+	const [ search, setSearch ] = useState( '' );
+	const [ role, setRole ] = useState( '' );
+
+	const perPage = 20;
+
+	const notifyError = useCallback(
+		( err ) =>
+			createErrorNotice(
+				err?.message ??
+					__( 'Something went wrong.', 'wp-login-logout-redirect' ),
+				{ type: 'snackbar', id: 'wplalr-sessions-error' }
+			),
+		[ createErrorNotice ]
+	);
+
+	const fetchSessions = useCallback( async () => {
+		setIsLoading( true );
+
+		try {
+			const path = addQueryArgs( SESSIONS_PATH, {
+				page,
+				per_page: perPage,
+				search,
+				role,
+			} );
+
+			const response = await apiFetch( { path, parse: false } );
+			const data = await response.json();
+
+			setItems( Array.isArray( data ) ? data : [] );
+			setTotal(
+				parseInt( response.headers.get( 'X-WP-Total' ) || '0', 10 )
+			);
+			setTotalPages(
+				parseInt( response.headers.get( 'X-WP-TotalPages' ) || '0', 10 )
+			);
+		} catch ( err ) {
+			notifyError( err );
+		} finally {
+			setIsLoading( false );
+		}
+	}, [ page, search, role, notifyError ] );
+
+	useEffect( () => {
+		fetchSessions();
+	}, [ fetchSessions ] );
+
+	const refresh = useCallback( () => fetchSessions(), [ fetchSessions ] );
+
+	const withResult = useCallback(
+		async ( request, successMessage ) => {
+			try {
+				await request();
+				if ( successMessage ) {
+					createSuccessNotice( successMessage, {
+						type: 'snackbar',
+						id: 'wplalr-sessions-action',
+					} );
+				}
+				fetchSessions();
+			} catch ( err ) {
+				notifyError( err );
+			}
+		},
+		[ createSuccessNotice, fetchSessions, notifyError ]
+	);
+
+	const destroySession = useCallback(
+		( userId, tokenId ) =>
+			withResult(
+				() =>
+					apiFetch( {
+						path: `${ SESSIONS_PATH }/${ userId }/${ tokenId }`,
+						method: 'DELETE',
+					} ),
+				__( 'Session ended.', 'wp-login-logout-redirect' )
+			),
+		[ withResult ]
+	);
+
+	const destroyUser = useCallback(
+		( userId ) =>
+			withResult(
+				() =>
+					apiFetch( {
+						path: `${ SESSIONS_PATH }/${ userId }`,
+						method: 'DELETE',
+					} ),
+				__( 'User logged out.', 'wp-login-logout-redirect' )
+			),
+		[ withResult ]
+	);
+
+	const destroyBulk = useCallback(
+		( userIds, excludeSelf = true ) =>
+			withResult(
+				() =>
+					apiFetch( {
+						path: `${ SESSIONS_PATH }/bulk-destroy`,
+						method: 'POST',
+						data: {
+							user_ids: userIds,
+							exclude_self: excludeSelf,
+						},
+					} ),
+				__( 'Selected users logged out.', 'wp-login-logout-redirect' )
+			),
+		[ withResult ]
+	);
+
+	const destroyAll = useCallback(
+		( excludeSelf = true ) =>
+			withResult(
+				() =>
+					apiFetch( {
+						path: `${ SESSIONS_PATH }/destroy-all`,
+						method: 'POST',
+						data: { exclude_self: excludeSelf },
+					} ),
+				__( 'Everyone logged out.', 'wp-login-logout-redirect' )
+			),
+		[ withResult ]
+	);
+
+	const updateSearch = useCallback( ( value ) => {
+		setSearch( value );
+		setPage( 1 );
+	}, [] );
+
+	const updateRole = useCallback( ( value ) => {
+		setRole( value );
+		setPage( 1 );
+	}, [] );
+
+	return {
+		items,
+		total,
+		totalPages,
+		isLoading,
+		page,
+		search,
+		role,
+		setPage,
+		setSearch: updateSearch,
+		setRole: updateRole,
+		refresh,
+		destroySession,
+		destroyUser,
+		destroyBulk,
+		destroyAll,
+	};
+};

--- a/src/shared/PageShell.js
+++ b/src/shared/PageShell.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, SnackbarList } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import SettingsHeader from '../components/SettingsHeader';
+import { Squares2X2Icon } from '../components/icons';
+import { getNavItems } from './navItems';
+
+/**
+ * Shared chrome for every admin page: header, cross-page nav, snackbars.
+ *
+ * The three submenu pages are separate WordPress URLs (full page loads), so the
+ * cross-page nav is plain links rather than a client router; the active page is
+ * highlighted via `current`.
+ *
+ * @param {Object}  props          Component props.
+ * @param {string}  props.current  Active page slug (matches a nav item `page`).
+ * @param {Element} props.children The active view.
+ */
+const PageShell = ( { current, children } ) => {
+	const notices = useSelect(
+		( select ) => select( noticesStore ).getNotices(),
+		[]
+	);
+	const { removeNotice } = useDispatch( noticesStore );
+	const snackbarNotices = notices.filter(
+		( notice ) => notice.type === 'snackbar'
+	);
+
+	const adminUrl = window.wplalrAdmin?.adminUrl || '';
+	const navItems = getNavItems();
+
+	// Pro extensions add header actions via this filter.
+	const headerActions = applyFilters(
+		'wplalr_header_actions',
+		<>
+			<Button
+				variant="secondary"
+				href="https://wordpress.org/plugins/wp-login-and-logout-redirect/"
+				target="_blank"
+				rel="noreferrer"
+			>
+				{ __( 'Documentation', 'wp-login-logout-redirect' ) }
+			</Button>
+			<Button
+				variant="primary"
+				href="https://buymeacoffee.com/aiarnob"
+				target="_blank"
+				rel="noreferrer"
+			>
+				{ __( 'Support Me', 'wp-login-logout-redirect' ) }
+			</Button>
+		</>
+	);
+
+	return (
+		<div className="wplalr-admin-app">
+			<SettingsHeader
+				icon={ Squares2X2Icon }
+				title={ __(
+					'WP Login and Logout Redirect',
+					'wp-login-logout-redirect'
+				) }
+				subTitle={ __(
+					'Configure where users are sent after they log in or log out.',
+					'wp-login-logout-redirect'
+				) }
+				actions={ headerActions }
+			/>
+
+			<nav className="wplalr-page-nav">
+				{ navItems.map( ( { page, label } ) => (
+					<a
+						key={ page }
+						href={ `${ adminUrl }admin.php?page=${ page }` }
+						className={ page === current ? 'is-active' : '' }
+						aria-current={ page === current ? 'page' : undefined }
+					>
+						{ label }
+					</a>
+				) ) }
+			</nav>
+
+			<main className="wplalr-main-content wplalr-setting-wrapper">
+				<div className="wplalr-content-body">{ children }</div>
+			</main>
+
+			<SnackbarList
+				notices={ snackbarNotices }
+				className="components-editor-notices__snackbar"
+				onRemove={ removeNotice }
+			/>
+		</div>
+	);
+};
+
+export default PageShell;

--- a/src/shared/navItems.js
+++ b/src/shared/navItems.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Cross-page navigation for the shared admin chrome.
+ *
+ * Each item maps to a WordPress admin submenu page (a full page load). Pro
+ * extensions can add their own pages/links via the `wplalr_admin_nav_items`
+ * filter without patching the free app.
+ *
+ * @return {Array<{page: string, label: string}>} Nav items.
+ */
+export const getNavItems = () =>
+	applyFilters( 'wplalr_admin_nav_items', [
+		{
+			page: 'wplalr_login_logout_redirect',
+			label: __( 'Redirect Options', 'wp-login-logout-redirect' ),
+		},
+		{
+			page: 'wplalr_audit_logs',
+			label: __( 'Audit Logs', 'wp-login-logout-redirect' ),
+		},
+		{
+			page: 'wplalr_sessions',
+			label: __( 'Logged-in Users', 'wp-login-logout-redirect' ),
+		},
+	] );

--- a/src/views/AuditLogsApp.js
+++ b/src/views/AuditLogsApp.js
@@ -1,31 +1,12 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '@wordpress/components';
+import LogsViewer from '../components/LogsViewer';
 
 /**
- * The Audit Logs view.
- *
- * Placeholder shell — the LogsViewer + useLogs hook land here per
- * docs/audit-logs-plan.md (Phase 1).
+ * The Audit Logs view: login/logout/failed-login history with stat cards,
+ * logging controls, filters and a paginated table.
  */
-const AuditLogsApp = () => (
-	<div className="wplalr-section">
-		<Card>
-			<CardBody className="wplalr-form-section-body">
-				<h2 className="wplalr-section-title">
-					{ __( 'Audit Logs', 'wp-login-logout-redirect' ) }
-				</h2>
-				<p className="wplalr-section-description">
-					{ __(
-						'Login, logout and failed-login history will appear here.',
-						'wp-login-logout-redirect'
-					) }
-				</p>
-			</CardBody>
-		</Card>
-	</div>
-);
+const AuditLogsApp = () => <LogsViewer />;
 
 export default AuditLogsApp;

--- a/src/views/AuditLogsApp.js
+++ b/src/views/AuditLogsApp.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Card, CardBody } from '@wordpress/components';
+
+/**
+ * The Audit Logs view.
+ *
+ * Placeholder shell — the LogsViewer + useLogs hook land here per
+ * docs/audit-logs-plan.md (Phase 1).
+ */
+const AuditLogsApp = () => (
+	<div className="wplalr-section">
+		<Card>
+			<CardBody className="wplalr-form-section-body">
+				<h2 className="wplalr-section-title">
+					{ __( 'Audit Logs', 'wp-login-logout-redirect' ) }
+				</h2>
+				<p className="wplalr-section-description">
+					{ __(
+						'Login, logout and failed-login history will appear here.',
+						'wp-login-logout-redirect'
+					) }
+				</p>
+			</CardBody>
+		</Card>
+	</div>
+);
+
+export default AuditLogsApp;

--- a/src/views/SessionsApp.js
+++ b/src/views/SessionsApp.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Card, CardBody } from '@wordpress/components';
+
+/**
+ * The Logged-in Users view.
+ *
+ * Placeholder shell — the SessionsViewer + useSessions hook land here per
+ * docs/logged-in-users-plan.md (Phase 2).
+ */
+const SessionsApp = () => (
+	<div className="wplalr-section">
+		<Card>
+			<CardBody className="wplalr-form-section-body">
+				<h2 className="wplalr-section-title">
+					{ __( 'Logged-in Users', 'wp-login-logout-redirect' ) }
+				</h2>
+				<p className="wplalr-section-description">
+					{ __(
+						'Active login sessions and force-logout controls will appear here.',
+						'wp-login-logout-redirect'
+					) }
+				</p>
+			</CardBody>
+		</Card>
+	</div>
+);
+
+export default SessionsApp;

--- a/src/views/SessionsApp.js
+++ b/src/views/SessionsApp.js
@@ -1,31 +1,12 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Card, CardBody } from '@wordpress/components';
+import SessionsViewer from '../components/SessionsViewer';
 
 /**
- * The Logged-in Users view.
- *
- * Placeholder shell — the SessionsViewer + useSessions hook land here per
- * docs/logged-in-users-plan.md (Phase 2).
+ * The Logged-in Users view: active login sessions with per-session, per-user,
+ * bulk and everyone force-logout controls.
  */
-const SessionsApp = () => (
-	<div className="wplalr-section">
-		<Card>
-			<CardBody className="wplalr-form-section-body">
-				<h2 className="wplalr-section-title">
-					{ __( 'Logged-in Users', 'wp-login-logout-redirect' ) }
-				</h2>
-				<p className="wplalr-section-description">
-					{ __(
-						'Active login sessions and force-logout controls will appear here.',
-						'wp-login-logout-redirect'
-					) }
-				</p>
-			</CardBody>
-		</Card>
-	</div>
-);
+const SessionsApp = () => <SessionsViewer />;
 
 export default SessionsApp;

--- a/src/views/SettingsApp.js
+++ b/src/views/SettingsApp.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
+
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { SettingsProvider } from '../context/SettingsContext';
+import Layout from '../components/Layout';
+import RedirectSettings from '../components/RedirectSettings';
+import RulesSettings from '../components/RulesSettings';
+
+/**
+ * The Redirects + Rules settings view.
+ *
+ * Keeps its internal Redirects/Rules hash tabs (sub-views of this one page).
+ * The page-level header/nav/snackbars live in the shared `PageShell`.
+ */
+const SettingsApp = () => {
+	// Pro extensions add routes here via the `wplalr_routes` filter.
+	const routes = applyFilters( 'wplalr_routes', [
+		{ path: 'rules', element: <RulesSettings /> },
+	] );
+
+	return (
+		<SettingsProvider>
+			<Router>
+				<Routes>
+					<Route path="/" element={ <Layout /> }>
+						<Route index element={ <RedirectSettings /> } />
+						{ routes.map( ( { path, element } ) => (
+							<Route
+								key={ path }
+								path={ path }
+								element={ element }
+							/>
+						) ) }
+					</Route>
+				</Routes>
+			</Router>
+		</SettingsProvider>
+	);
+};
+
+export default SettingsApp;

--- a/src/views/SettingsApp.js
+++ b/src/views/SettingsApp.js
@@ -15,6 +15,7 @@ import { SettingsProvider } from '../context/SettingsContext';
 import Layout from '../components/Layout';
 import RedirectSettings from '../components/RedirectSettings';
 import RulesSettings from '../components/RulesSettings';
+import OthersSettings from '../components/OthersSettings';
 
 /**
  * The Redirects + Rules settings view.
@@ -26,6 +27,7 @@ const SettingsApp = () => {
 	// Pro extensions add routes here via the `wplalr_routes` filter.
 	const routes = applyFilters( 'wplalr_routes', [
 		{ path: 'rules', element: <RulesSettings /> },
+		{ path: 'others', element: <OthersSettings /> },
 	] );
 
 	return (


### PR DESCRIPTION
> ## 🧱 Stack level 3 of 4 — merge order #3
> This PR is part of a stacked chain. Merge **bottom-up** (closest to `develop` first):
> 1. #11 `feature/react-admin-settings` → `develop` *(merge first)*
> 2. #10 `feature/redirect-rule-engine` → `feature/react-admin-settings`
> 3. #9 `feature/admin-subpages` → `feature/redirect-rule-engine`
> 4. #8 `feature/audit-log-notifier` → `feature/admin-subpages` *(merge last)*
>
> **This PR: Level 3 — merge after #10** — check/merge after everything below it is merged.
## Summary

Builds the admin subpages on top of the redirect rule engine:

- **Audit Logs** page — login / logout / failed-login history (Phase 1).
- **Logged-in Users** page with force-logout (Phase 2).
- **Others** tab — moves logging settings out of the Audit Logs page into a dedicated settings tab.
- Shared admin bundle drives all subpages.

## Commits
- Add Audit Logs and Logged-in Users submenu pages (shared bundle)
- Add audit logs: login/logout/failed-login history (Phase 1)
- Add logged-in users & force logout (Phase 2)
- Add Others tab; move logging settings out of Audit Logs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)