### PR TITLE
Add redirect rule engine with React Rules UI

### DIFF
--- a/docs/browser-test-cases.md
+++ b/docs/browser-test-cases.md
@@ -1,0 +1,251 @@
+# Browser test cases (Claude-in-Chrome)
+
+Manual/automated UI test plan for the React admin settings, written so it can be
+driven by the Claude-in-Chrome browser tools. Each case lists the browser
+actions and how to verify the outcome (screenshot, `wp-cli`, or console).
+
+## Environment & setup
+
+- **Settings URL:** `https://woocommerce.test/wp-admin/admin.php?page=wplalr_login_logout_redirect`
+- **Auth:** must be logged in as an admin (`manage_options`). If the page shows the
+  WP login form, stop and ask the user to log in.
+- **Screen id:** `toplevel_page_wplalr_login_logout_redirect` (admin bundle only
+  enqueues here).
+- **Tooling:** start with `tabs_context_mcp`, then `navigate`; capture state with
+  `computer` screenshots; debug with `read_console_messages`.
+
+### State helpers (run in the project dir via shell)
+
+```bash
+# Inspect stored rules
+wp option get wplalr_redirect_rules --format=json
+
+# Inspect the default fallback URLs
+wp option get wplalr_login_redirect
+wp option get wplalr_logout_redirect
+
+# Reset to a clean slate before/after a run
+wp option update wplalr_redirect_rules '[]' --format=json
+```
+
+### Pass criteria for every case
+
+- No uncaught errors in `read_console_messages` (the benign
+  `InvalidStateError: Transition was aborted...` at `:0:0` is a Chrome
+  view-transition artifact and may be ignored — it has no plugin stack).
+- No PHP critical-error snackbar ("There has been a critical error on this website").
+
+---
+
+## TC-01 — Page loads with both tabs
+
+**Steps**
+1. `navigate` to the settings URL.
+2. Screenshot.
+
+**Expected**
+- Header "WP Login and Logout Redirect" with Documentation + Support Me buttons.
+- Two tabs: **Redirects** (active) and **Rules**.
+- Defaults card titled "Default Redirect URLs" with Login/Logout URL fields and the
+  placeholder hint `Placeholders: {{username}}, {{user_slug}}, {{website_url}}`.
+
+## TC-02 — Save default redirect URLs
+
+**Steps**
+1. On the Redirects tab, set Login URL = `https://woocommerce.test/after-login`,
+   Logout URL = `https://woocommerce.test/after-logout`.
+2. Click **Save Changes**. Screenshot.
+
+**Expected**
+- "Settings saved successfully!" snackbar.
+- `wp option get wplalr_login_redirect` → `https://woocommerce.test/after-login`.
+- `wp option get wplalr_logout_redirect` → `https://woocommerce.test/after-logout`.
+
+## TC-03 — Switch to Rules tab (empty state)
+
+**Steps**
+1. Click the **Rules** tab (URL hash becomes `#/rules`).
+2. Screenshot.
+
+**Expected**
+- "Redirect Rules" header with explanatory text.
+- Empty state: "No rules yet. Add a rule to redirect specific roles, users, or capabilities."
+- **Add rule** and **Save Rules** buttons visible.
+
+## TC-04 — Add a rule with a role condition
+
+**Steps**
+1. Click **Add rule**. A rule card appears (drag handle, name field, Enabled toggle, delete).
+2. Type a name, e.g. `Editors to dashboard`.
+3. Click **Add condition** → a condition row appears with **When = Role** and a Roles field.
+4. Click the Roles field, type `Edit`, and pick the **Editor** suggestion.
+5. Set **Login redirect URL** = `https://woocommerce.test/editor-home/`.
+6. Click **Save Rules**. Screenshot.
+
+**Expected**
+- Role autocomplete shows "Editor" while typing (roles are localized into the page).
+- Selected role renders as a token chip "Editor ×".
+- "Redirect rules saved!" snackbar.
+- `wp option get wplalr_redirect_rules --format=json` contains one rule with a
+  server-assigned UUID `id`, `enabled: true`, the label, `conditions: [{type:"role",
+  values:["editor"]}]` (stored as the **slug**, not the display name), and the
+  login URL. `logout_url` empty.
+
+## TC-05 — Persistence / round-trip on reload
+
+**Steps**
+1. Full-reload the settings URL with `#/rules` (use `navigate`, not just a hash change,
+   to force a fresh fetch).
+2. Screenshot.
+
+**Expected**
+- The saved rule re-renders: name, the **Editor** token (slug→name mapping on load),
+  and the login URL all intact.
+
+## TC-06 — Capability condition (free-text tokens)
+
+**Steps**
+1. On a rule, set a condition **When = Capability**.
+2. In the field, type `edit_pages` and press Enter; add `manage_options`.
+3. Save. Verify option.
+
+**Expected**
+- Both capabilities stored as `conditions: [{type:"capability", values:["edit_pages","manage_options"]}]`.
+
+## TC-07 — Specific-user condition (async search)
+
+**Steps**
+1. Add a condition **When = Specific user**.
+2. Type part of a username/display name; pick a suggestion formatted `Name (#id)`.
+3. Save. Verify option.
+
+**Expected**
+- Suggestions load from `/wp/v2/users` as you type (debounced).
+- Stored value is the numeric user **ID** (string), e.g. `values:["9"]`.
+- On reload, the token shows the user label, not a bare id.
+
+## TC-08 — Multi-condition AND
+
+**Steps**
+1. On one rule, add two conditions: Role = `Editor` AND Capability = `edit_pages`.
+2. Save and verify the option holds both conditions in the `conditions` array.
+
+**Expected**
+- Rule stores both conditions; runtime requires **all** to match (AND). (Behavioral
+  match is covered by the PHP unit harness, not the browser.)
+
+## TC-09 — Add a second rule and drag-reorder
+
+**Steps**
+1. Add a second rule named `Second rule`.
+2. Scroll so both rule cards' drag handles (the `≡` icon) are visible.
+3. `left_click_drag` the second rule's handle above the first rule.
+4. Screenshot, then **Save Rules**.
+
+**Expected**
+- After drag, "Second rule" appears first in the list.
+- After save, `wp option get wplalr_redirect_rules --format=json` shows the new order
+  (Second rule at index 0).
+
+## TC-10 — Toggle Enabled off
+
+**Steps**
+1. Turn a rule's **Enabled** toggle off. Save. Verify option.
+
+**Expected**
+- Rule persists with `enabled: false`. (Disabled rules are skipped at runtime.)
+
+## TC-11 — Delete a rule
+
+**Steps**
+1. Click the trash icon on a rule card. The card disappears immediately.
+2. Save. Verify option.
+
+**Expected**
+- The deleted rule is gone from the list and from `wplalr_redirect_rules` after save.
+
+## TC-12 — Delete all rules → empty state
+
+**Steps**
+1. Delete every rule, then **Save Rules**.
+2. Screenshot.
+
+**Expected**
+- Empty-state message returns; `wp option get wplalr_redirect_rules` → `[]`.
+
+## TC-13 — Placeholder hint present on rule cards
+
+**Steps**
+1. On any rule card, confirm the hint under the URL fields.
+
+**Expected**
+- Monospace line: `Placeholders: {{username}}, {{user_slug}}, {{website_url}}`.
+
+## TC-14 — No-op extension filters don't break the UI
+
+**Steps**
+1. With no Pro plugin active, exercise TC-03/TC-04.
+
+**Expected**
+- `wplalr_tabs`, `wplalr_routes`, `wplalr_header_actions`, `wplalr_condition_types`,
+  `wplalr_condition_value_control`, `wplalr_rule_fields` all return defaults; the UI is
+  unchanged and no console errors appear.
+
+## TC-15 — Server-side validation hardening
+
+**Steps**
+1. (Optional, via REST/console) POST to `wplalr/v1/settings` a rule with a bogus role
+   (`values:["not_a_role"]`) and a bogus user id (`values:["999999"]`).
+
+**Expected**
+- Invalid values are dropped server-side (role not in `wp_roles()`, user id not found);
+  the saved option contains only valid values. No fatal error.
+
+---
+
+## Behavioral redirect checks (optional, needs a second account)
+
+These verify the actual redirect, not just the admin UI. They require logging in/out,
+so run in a separate browser profile or incognito to avoid disturbing the admin session.
+
+## TC-B1 — Role rule redirects on login
+
+**Setup:** a rule matching role `subscriber` → login URL `…/welcome/`.
+
+**Steps**
+1. In a clean profile, log in as a subscriber via `wp-login.php`.
+
+**Expected**
+- Lands on `…/welcome/` (rule wins over the default).
+
+## TC-B2 — Default fallback on login
+
+**Setup:** no rule matches the logging-in user; default login URL set.
+
+**Expected**
+- Lands on the default login URL.
+
+## TC-B3 — Placeholder expansion
+
+**Setup:** a rule login URL `{{website_url}}/u/{{username}}/`.
+
+**Expected**
+- Redirect resolves to `https://woocommerce.test/u/<login>/`.
+
+## TC-B4 — Loop guard
+
+**Setup:** set a login redirect to the login page URL (`…/wp-login.php`).
+
+**Expected**
+- The loop guard blocks it; the user lands on `admin_url()` instead of bouncing.
+
+---
+
+## Regression checklist (run before release)
+
+- [ ] `composer phpcs` → 0 errors / 0 warnings.
+- [ ] `npm run lint:js` → exit 0.
+- [ ] `npm run build` → compiles; `assets/build/admin/script.asset.php` lists
+      `wp-components`, `wp-api-fetch`, `wp-data`, `wp-element`, `wp-i18n`,
+      `wp-notices`, `wp-url`, `wp-hooks`.
+- [ ] TC-01 … TC-15 pass with no plugin console errors.

--- a/docs/browser-test-cases.md
+++ b/docs/browser-test-cases.md
@@ -4,6 +4,13 @@ Manual/automated UI test plan for the React admin settings, written so it can be
 driven by the Claude-in-Chrome browser tools. Each case lists the browser
 actions and how to verify the outcome (screenshot, `wp-cli`, or console).
 
+## Last run
+
+**2026-06-24 — all cases PASS.** TC-01…TC-15 (admin UI) run in Chrome as `admin`;
+TC-B1…TC-B4 (behavioral) run as a real subscriber login (`user`, ID 4) on
+`woocommerce.test`. Per-case results are recorded inline below. Notable findings
+from that run are collected under [Run notes](#run-notes).
+
 ## Environment & setup
 
 - **Settings URL:** `https://woocommerce.test/wp-admin/admin.php?page=wplalr_login_logout_redirect`
@@ -49,6 +56,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - Defaults card titled "Default Redirect URLs" with Login/Logout URL fields and the
   placeholder hint `Placeholders: {{username}}, {{user_slug}}, {{website_url}}`.
 
+**Result:** ✅ PASS (2026-06-24) — header, both tabs, defaults card and hint all present.
+
 ## TC-02 — Save default redirect URLs
 
 **Steps**
@@ -61,6 +70,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - `wp option get wplalr_login_redirect` → `https://woocommerce.test/after-login`.
 - `wp option get wplalr_logout_redirect` → `https://woocommerce.test/after-logout`.
 
+**Result:** ✅ PASS (2026-06-24) — snackbar shown, both options persisted.
+
 ## TC-03 — Switch to Rules tab (empty state)
 
 **Steps**
@@ -71,6 +82,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - "Redirect Rules" header with explanatory text.
 - Empty state: "No rules yet. Add a rule to redirect specific roles, users, or capabilities."
 - **Add rule** and **Save Rules** buttons visible.
+
+**Result:** ✅ PASS (2026-06-24) — empty-state message, hash `#/rules`, both buttons visible.
 
 ## TC-04 — Add a rule with a role condition
 
@@ -91,6 +104,9 @@ wp option update wplalr_redirect_rules '[]' --format=json
   values:["editor"]}]` (stored as the **slug**, not the display name), and the
   login URL. `logout_url` empty.
 
+**Result:** ✅ PASS (2026-06-24) — autocomplete + token chip worked; stored UUID,
+`role:["editor"]` (slug), login URL, empty `logout_url`.
+
 ## TC-05 — Persistence / round-trip on reload
 
 **Steps**
@@ -102,6 +118,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - The saved rule re-renders: name, the **Editor** token (slug→name mapping on load),
   and the login URL all intact.
 
+**Result:** ✅ PASS (2026-06-24) — name, Editor token, and URL re-rendered after fresh navigate.
+
 ## TC-06 — Capability condition (free-text tokens)
 
 **Steps**
@@ -111,6 +129,9 @@ wp option update wplalr_redirect_rules '[]' --format=json
 
 **Expected**
 - Both capabilities stored as `conditions: [{type:"capability", values:["edit_pages","manage_options"]}]`.
+
+**Result:** ✅ PASS (2026-06-24) — both capability tokens stored. Switching a condition's
+**When** type clears the previous values field.
 
 ## TC-07 — Specific-user condition (async search)
 
@@ -124,6 +145,9 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - Stored value is the numeric user **ID** (string), e.g. `values:["9"]`.
 - On reload, the token shows the user label, not a bare id.
 
+**Result:** ✅ PASS (2026-06-24) — `admin (#1)` suggestion; stored `values:["1"]`;
+on reload the token still showed the `admin (#1)` label.
+
 ## TC-08 — Multi-condition AND
 
 **Steps**
@@ -133,6 +157,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 **Expected**
 - Rule stores both conditions; runtime requires **all** to match (AND). (Behavioral
   match is covered by the PHP unit harness, not the browser.)
+
+**Result:** ✅ PASS (2026-06-24) — both `role` and `capability` conditions stored on the rule.
 
 ## TC-09 — Add a second rule and drag-reorder
 
@@ -147,6 +173,12 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - After save, `wp option get wplalr_redirect_rules --format=json` shows the new order
   (Second rule at index 0).
 
+**Result:** ✅ PASS (2026-06-24) — reordered; `Second rule` at index 0 after save.
+**Automation note:** a pixel `left_click_drag` is unreliable here because a tall rule
+card pushes both handles outside one viewport. The handle is keyboard-operable
+(dnd-kit): focus the **Reorder rule** button, press `Space` to pick up, `Up`/`Down`
+to move, `Space` to drop. That path was used and works.
+
 ## TC-10 — Toggle Enabled off
 
 **Steps**
@@ -154,6 +186,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 
 **Expected**
 - Rule persists with `enabled: false`. (Disabled rules are skipped at runtime.)
+
+**Result:** ✅ PASS (2026-06-24) — rule persisted with `enabled: false`.
 
 ## TC-11 — Delete a rule
 
@@ -164,6 +198,9 @@ wp option update wplalr_redirect_rules '[]' --format=json
 **Expected**
 - The deleted rule is gone from the list and from `wplalr_redirect_rules` after save.
 
+**Result:** ✅ PASS (2026-06-24) — card removed immediately (no confirm dialog), gone
+from the option after save.
+
 ## TC-12 — Delete all rules → empty state
 
 **Steps**
@@ -173,6 +210,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 **Expected**
 - Empty-state message returns; `wp option get wplalr_redirect_rules` → `[]`.
 
+**Result:** ✅ PASS (2026-06-24) — empty-state message returned; option `[]`.
+
 ## TC-13 — Placeholder hint present on rule cards
 
 **Steps**
@@ -180,6 +219,8 @@ wp option update wplalr_redirect_rules '[]' --format=json
 
 **Expected**
 - Monospace line: `Placeholders: {{username}}, {{user_slug}}, {{website_url}}`.
+
+**Result:** ✅ PASS (2026-06-24) — hint present on every rule card.
 
 ## TC-14 — No-op extension filters don't break the UI
 
@@ -191,6 +232,10 @@ wp option update wplalr_redirect_rules '[]' --format=json
   `wplalr_condition_value_control`, `wplalr_rule_fields` all return defaults; the UI is
   unchanged and no console errors appear.
 
+**Result:** ✅ PASS (2026-06-24) — UI unchanged. Console showed only two benign React
+Router v7 future-flag **warnings** (`v7_startTransition`, `v7_relativeSplatPath`);
+no errors, no PHP critical-error snackbar.
+
 ## TC-15 — Server-side validation hardening
 
 **Steps**
@@ -201,12 +246,32 @@ wp option update wplalr_redirect_rules '[]' --format=json
 - Invalid values are dropped server-side (role not in `wp_roles()`, user id not found);
   the saved option contains only valid values. No fatal error.
 
+**Result:** ✅ PASS (2026-06-24) — status 200; `not_a_role` and `999999` dropped,
+`editor`/`1` kept; no fatal.
+**Note:** the rules array is sent/received under the param key **`rules`** (not
+`redirect_rules`). A convenient way to exercise the exact sanitizer without a browser
+nonce is `wp eval` + `rest_do_request`:
+
+```php
+wp_set_current_user( 1 );
+$req = new WP_REST_Request( 'POST', '/wplalr/v1/settings' );
+$req->set_header( 'Content-Type', 'application/json' );
+$req->set_body( wp_json_encode( array( 'rules' => array( /* rule(s) */ ) ) ) );
+$res = rest_do_request( $req );
+// $res->get_data()['rules'] holds the sanitized result.
+```
+
 ---
 
 ## Behavioral redirect checks (optional, needs a second account)
 
 These verify the actual redirect, not just the admin UI. They require logging in/out,
 so run in a separate browser profile or incognito to avoid disturbing the admin session.
+
+> **Can't enter passwords?** If the automation harness cannot type credentials, you can
+> still verify the same code path without a browser login by calling the plugin's
+> redirect resolver directly (see the [Run notes](#run-notes) — "Filter-level
+> verification"). The browser run below is the genuine end-to-end check.
 
 ## TC-B1 — Role rule redirects on login
 
@@ -218,12 +283,18 @@ so run in a separate browser profile or incognito to avoid disturbing the admin 
 **Expected**
 - Lands on `…/welcome/` (rule wins over the default).
 
+**Result:** ✅ PASS (2026-06-24) — subscriber `user` landed on
+`http://woocommerce.test/welcome/` (404 page is fine — only the redirect target matters).
+
 ## TC-B2 — Default fallback on login
 
 **Setup:** no rule matches the logging-in user; default login URL set.
 
 **Expected**
 - Lands on the default login URL.
+
+**Result:** ✅ PASS (2026-06-24) — with only an `administrator` rule, subscriber `user`
+fell back to the default `http://woocommerce.test/after-login`.
 
 ## TC-B3 — Placeholder expansion
 
@@ -232,6 +303,9 @@ so run in a separate browser profile or incognito to avoid disturbing the admin 
 **Expected**
 - Redirect resolves to `https://woocommerce.test/u/<login>/`.
 
+**Result:** ✅ PASS (2026-06-24) — resolved to `http://woocommerce.test/u/user/`
+(`{{website_url}}` + `{{username}}` expanded).
+
 ## TC-B4 — Loop guard
 
 **Setup:** set a login redirect to the login page URL (`…/wp-login.php`).
@@ -239,7 +313,43 @@ so run in a separate browser profile or incognito to avoid disturbing the admin 
 **Expected**
 - The loop guard blocks it; the user lands on `admin_url()` instead of bouncing.
 
+**Result:** ✅ PASS (2026-06-24) — the user did **not** bounce back to `wp-login.php`
+(the loop the guard prevents). The plugin resolved to `admin_url()` as designed.
+**Caveat:** for a subscriber, WooCommerce then redirects `/wp-admin/` → `/my-account/`
+(customers/subscribers are blocked from admin), so the observed final URL was
+`…/my-account/`, not `/wp-admin/`. Testing with a user who *can* access admin would land
+on `/wp-admin/` directly.
+
 ---
+
+## Run notes
+
+Observations from the 2026-06-24 run that aren't obvious from the steps:
+
+- **TC-09 drag-reorder:** prefer dnd-kit keyboard reordering (focus handle → `Space` →
+  arrows → `Space`) over a pixel drag; tall cards put both handles out of one viewport.
+- **TC-15 param key:** the REST rules param is **`rules`**, not `redirect_rules`. The
+  response also returns rules under `rules`.
+- **StoreSuite interferes with filter-level testing.** Another active plugin
+  (`storesuite`) hooks `login_redirect` and calls `wp_safe_redirect()` inside the
+  callback, so firing `apply_filters( 'login_redirect', … )` in WP-CLI aborts the run
+  ("Some code is trying to do a URL redirect"). In a real browser login our redirect
+  still wins (confirmed in TC-B1–B3).
+- **Filter-level verification (no password needed).** To check redirect logic without a
+  browser login, construct the plugin's resolver and call it directly — this bypasses
+  other plugins on the hook:
+
+  ```php
+  use PluginizeLab\WpLoginLogoutRedirect\{Redirection, RuleEngine, Placeholders};
+  $redir = new Redirection( new RuleEngine(), new Placeholders() );
+  $user  = get_user_by( 'id', 4 ); // a subscriber
+  echo $redir->login_redirect( admin_url(), '', $user );
+  ```
+
+  Set `wplalr_redirect_rules` / `wplalr_login_redirect` per scenario first, and restore
+  them afterward. This is a code-level equivalent of TC-B1–B4, not a real login.
+- **Snackbars auto-dismiss.** After clicking a Save button, screenshot promptly (≤1s) or
+  the success snackbar may have already faded.
 
 ## Regression checklist (run before release)
 
@@ -249,3 +359,4 @@ so run in a separate browser profile or incognito to avoid disturbing the admin 
       `wp-components`, `wp-api-fetch`, `wp-data`, `wp-element`, `wp-i18n`,
       `wp-notices`, `wp-url`, `wp-hooks`.
 - [ ] TC-01 … TC-15 pass with no plugin console errors.
+- [ ] TC-B1 … TC-B4 pass (real login or filter-level verification).

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -9,36 +9,36 @@ without forking its bundle. Stable as of Phase 4.
 
 | Hook | Type | Signature | Purpose |
 |------|------|-----------|---------|
-| `wplalr/before_resolve` | action | `( string $event, ?WP_User $user )` | Fires before a login/logout URL is resolved. |
-| `wplalr/match_condition` | filter | `( bool $matched, string $type, array $values, WP_User $user )` | Resolve a match for a **custom** condition type the free plugin does not handle. |
-| `wplalr/resolve_redirect` | filter | `( string $url, ?WP_User $user, ?array $matched, string $event )` | Override the resolved URL (e.g. referrer, WooCommerce/EDD flows). |
-| `wplalr/after_resolve` | action | `( string $url, string $event, ?WP_User $user, ?array $matched )` | Fires after resolution. |
+| `wplalr_before_resolve` | action | `( string $event, ?WP_User $user )` | Fires before a login/logout URL is resolved. |
+| `wplalr_match_condition` | filter | `( bool $matched, string $type, array $values, WP_User $user )` | Resolve a match for a **custom** condition type the free plugin does not handle. |
+| `wplalr_resolve_redirect` | filter | `( string $url, ?WP_User $user, ?array $matched, string $event )` | Override the resolved URL (e.g. referrer, WooCommerce/EDD flows). |
+| `wplalr_after_resolve` | action | `( string $url, string $event, ?WP_User $user, ?array $matched )` | Fires after resolution. |
 
 ### Placeholders (`Placeholders`)
 
 | Hook | Type | Signature | Purpose |
 |------|------|-----------|---------|
-| `wplalr/placeholders` | filter | `( array $map, ?WP_User $user )` | Add tokens to the `{{token}} => value` map (e.g. `{{current_page}}`, `{{previous_page}}`). |
+| `wplalr_placeholders` | filter | `( array $map, ?WP_User $user )` | Add tokens to the `{{token}} => value` map (e.g. `{{current_page}}`, `{{previous_page}}`). |
 
 ### Redirect safety (`Redirection`)
 
 | Hook | Type | Signature | Purpose |
 |------|------|-----------|---------|
-| `wplalr/allow_external_redirect` | filter | `( bool $allow, string $redirect_url )` | Return `false` to enforce a same-site-only policy on logout. |
+| `wplalr_allow_external_redirect` | filter | `( bool $allow, string $redirect_url )` | Return `false` to enforce a same-site-only policy on logout. |
 
 ### REST + match types (`REST\SettingsController`)
 
 | Hook | Type | Signature | Purpose |
 |------|------|-----------|---------|
-| `wplalr/rule_match_types` | filter | `( array $types )` | Register custom condition match-type slugs. |
-| `wplalr/sanitize_condition_values` | filter | `( array $clean, string $type, array $values )` | Sanitize values for a custom match type. |
-| `wplalr/rest/rule_schema` | filter | `( array $schema )` | Extend the REST schema for a single rule. |
-| `wplalr/rest/sanitize_rule` | filter | `( array $clean_rule, array $raw_rule )` | Add sanitized custom fields to a rule before it is stored. |
-| `wplalr/rest/settings_response` | filter | `( array $settings )` | Add fields to the settings GET payload. |
+| `wplalr_rule_match_types` | filter | `( array $types )` | Register custom condition match-type slugs. |
+| `wplalr_sanitize_condition_values` | filter | `( array $clean, string $type, array $values )` | Sanitize values for a custom match type. |
+| `wplalr_rest_rule_schema` | filter | `( array $schema )` | Extend the REST schema for a single rule. |
+| `wplalr_rest_sanitize_rule` | filter | `( array $clean_rule, array $raw_rule )` | Add sanitized custom fields to a rule before it is stored. |
+| `wplalr_rest_settings_response` | filter | `( array $settings )` | Add fields to the settings GET payload. |
 
-A custom match type generally needs three hooks together: `wplalr/rule_match_types`
-(register it), `wplalr/sanitize_condition_values` (validate input), and
-`wplalr/match_condition` (evaluate it at runtime).
+A custom match type generally needs three hooks together: `wplalr_rule_match_types`
+(register it), `wplalr_sanitize_condition_values` (validate input), and
+`wplalr_match_condition` (evaluate it at runtime).
 
 ## JavaScript filters (`@wordpress/hooks`)
 
@@ -48,17 +48,17 @@ bundle declares `wp-hooks` as a dependency, so Pro scripts enqueued after
 
 | Filter | Value | Extra args | Purpose |
 |--------|-------|-----------|---------|
-| `wplalr.routes` | `Array<{ path, element }>` | — | Add HashRouter routes under the layout. |
-| `wplalr.tabs` | `Array<{ to, icon, label }>` | — | Add navigation tabs. |
-| `wplalr.headerActions` | React element | — | Replace/augment the header action buttons (e.g. an Upgrade CTA). |
-| `wplalr.conditionTypes` | `Array<{ label, value }>` | — | Add match-type options to the condition selector. |
-| `wplalr.conditionValueControl` | React element \| null | `{ type, values, onChange }` | Render the value control for a custom match type (return `null` to fall back). |
-| `wplalr.ruleFields` | React element \| null | `{ rule, onChange }` | Inject extra fields into each rule card (e.g. first-login-only, WooCommerce context). |
+| `wplalr_routes` | `Array<{ path, element }>` | — | Add HashRouter routes under the layout. |
+| `wplalr_tabs` | `Array<{ to, icon, label }>` | — | Add navigation tabs. |
+| `wplalr_header_actions` | React element | — | Replace/augment the header action buttons (e.g. an Upgrade CTA). |
+| `wplalr_condition_types` | `Array<{ label, value }>` | — | Add match-type options to the condition selector. |
+| `wplalr_condition_value_control` | React element \| null | `{ type, values, onChange }` | Render the value control for a custom match type (return `null` to fall back). |
+| `wplalr_rule_fields` | React element \| null | `{ rule, onChange }` | Inject extra fields into each rule card (e.g. first-login-only, WooCommerce context). |
 
 ## Data model note
 
 The free REST sanitizer keeps a fixed key set per rule, so optional Pro fields
-(`first_login_only`, `wc_context`, …) must be: declared via `wplalr/rest/rule_schema`,
-persisted via `wplalr/rest/sanitize_rule`, surfaced in the UI via `wplalr.ruleFields`,
-and acted on at runtime via `wplalr/resolve_redirect`. The free runtime ignores any
+(`first_login_only`, `wc_context`, …) must be: declared via `wplalr_rest_rule_schema`,
+persisted via `wplalr_rest_sanitize_rule`, surfaced in the UI via `wplalr_rule_fields`,
+and acted on at runtime via `wplalr_resolve_redirect`. The free runtime ignores any
 field it does not recognize.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,0 +1,64 @@
+# Extensibility — hooks for the Pro add-on
+
+These are the seams the separate Pro plugin uses to extend the free plugin
+without forking its bundle. Stable as of Phase 4.
+
+## PHP filters & actions
+
+### Rule resolution (`RuleEngine`)
+
+| Hook | Type | Signature | Purpose |
+|------|------|-----------|---------|
+| `wplalr/before_resolve` | action | `( string $event, ?WP_User $user )` | Fires before a login/logout URL is resolved. |
+| `wplalr/match_condition` | filter | `( bool $matched, string $type, array $values, WP_User $user )` | Resolve a match for a **custom** condition type the free plugin does not handle. |
+| `wplalr/resolve_redirect` | filter | `( string $url, ?WP_User $user, ?array $matched, string $event )` | Override the resolved URL (e.g. referrer, WooCommerce/EDD flows). |
+| `wplalr/after_resolve` | action | `( string $url, string $event, ?WP_User $user, ?array $matched )` | Fires after resolution. |
+
+### Placeholders (`Placeholders`)
+
+| Hook | Type | Signature | Purpose |
+|------|------|-----------|---------|
+| `wplalr/placeholders` | filter | `( array $map, ?WP_User $user )` | Add tokens to the `{{token}} => value` map (e.g. `{{current_page}}`, `{{previous_page}}`). |
+
+### Redirect safety (`Redirection`)
+
+| Hook | Type | Signature | Purpose |
+|------|------|-----------|---------|
+| `wplalr/allow_external_redirect` | filter | `( bool $allow, string $redirect_url )` | Return `false` to enforce a same-site-only policy on logout. |
+
+### REST + match types (`REST\SettingsController`)
+
+| Hook | Type | Signature | Purpose |
+|------|------|-----------|---------|
+| `wplalr/rule_match_types` | filter | `( array $types )` | Register custom condition match-type slugs. |
+| `wplalr/sanitize_condition_values` | filter | `( array $clean, string $type, array $values )` | Sanitize values for a custom match type. |
+| `wplalr/rest/rule_schema` | filter | `( array $schema )` | Extend the REST schema for a single rule. |
+| `wplalr/rest/sanitize_rule` | filter | `( array $clean_rule, array $raw_rule )` | Add sanitized custom fields to a rule before it is stored. |
+| `wplalr/rest/settings_response` | filter | `( array $settings )` | Add fields to the settings GET payload. |
+
+A custom match type generally needs three hooks together: `wplalr/rule_match_types`
+(register it), `wplalr/sanitize_condition_values` (validate input), and
+`wplalr/match_condition` (evaluate it at runtime).
+
+## JavaScript filters (`@wordpress/hooks`)
+
+Registered with `wp.hooks.addFilter( name, namespace, callback )`. The admin
+bundle declares `wp-hooks` as a dependency, so Pro scripts enqueued after
+`wplalr-admin-page` can hook these.
+
+| Filter | Value | Extra args | Purpose |
+|--------|-------|-----------|---------|
+| `wplalr.routes` | `Array<{ path, element }>` | — | Add HashRouter routes under the layout. |
+| `wplalr.tabs` | `Array<{ to, icon, label }>` | — | Add navigation tabs. |
+| `wplalr.headerActions` | React element | — | Replace/augment the header action buttons (e.g. an Upgrade CTA). |
+| `wplalr.conditionTypes` | `Array<{ label, value }>` | — | Add match-type options to the condition selector. |
+| `wplalr.conditionValueControl` | React element \| null | `{ type, values, onChange }` | Render the value control for a custom match type (return `null` to fall back). |
+| `wplalr.ruleFields` | React element \| null | `{ rule, onChange }` | Inject extra fields into each rule card (e.g. first-login-only, WooCommerce context). |
+
+## Data model note
+
+The free REST sanitizer keeps a fixed key set per rule, so optional Pro fields
+(`first_login_only`, `wc_context`, …) must be: declared via `wplalr/rest/rule_schema`,
+persisted via `wplalr/rest/sanitize_rule`, surfaced in the UI via `wplalr.ruleFields`,
+and acted on at runtime via `wplalr/resolve_redirect`. The free runtime ignores any
+field it does not recognize.

--- a/docs/free-pro-roadmap.md
+++ b/docs/free-pro-roadmap.md
@@ -1,0 +1,289 @@
+# WP Login and Logout Redirect — Free + Pro Roadmap & Spec
+
+Status: **Spec / planning** (no code yet). Supersedes and extends the analysis in
+[issue #3](https://github.com/aminurislamarnob/wp-login-and-logout-redirect/issues/3).
+
+## 1. Competitor analysis — verified
+
+Issue #3 compared us with LoginWP and Sky. Verified against actual plugin source
+(not just marketing copy), the claims hold. One competitor the user named was
+**missing from #3: fluent-security (FluentAuth)** — added below.
+
+| Capability | Us (today) | LoginWP free / Pro | Sky free / Pro | FluentAuth (all free) |
+|---|---|---|---|---|
+| Global login/logout URL | ✅ both | fallback rule / ✅ | ✅ / ✅ | default fallback |
+| Rule engine (role / user / capability) | ❌ | ✅ user+role+cap / ✅ | role+user+global / + conditional | **role + capability only** (no per-user) |
+| Default fallback rule | ✅ (the 2 options) | ✅ | ✅ | ✅ |
+| Separate login vs logout rules | global only | ✅ | ✅ | per-rule `login` + `logout` URL |
+| Placeholders `{{username}}` `{{user_slug}}` `{{website_url}}` | ❌ | ✅ free | — | ❌ |
+| `{{current_page}}` / `{{previous_page}}` (referrer) | ❌ | Pro | ✅ free ("previous page") | cookie `_fls_redirect_to` (free) |
+| First-login-only redirect | ❌ | Pro | — | ❌ |
+| Post-registration redirect | ❌ | ✅ free | — | ❌ |
+| Failed-login redirect | ❌ | ✅ (changelog) | — | ❌ |
+| Loop detection / URL hardening | `wp_validate_redirect` only | `wp_validate_redirect` | ✅ loop detection | `wp_validate_redirect`, priority 999 |
+| WooCommerce-aware | compat note | Pro | ✅ free / advanced Pro | partial |
+| EDD-aware | ❌ | Pro | Pro | ❌ |
+| Content restriction + redirect guests | ❌ | ❌ | Pro | restrict /wp-admin by role |
+| Last-login tracking | ✅ **(our differentiator)** | ❌ | ❌ | audit logs (own tables) |
+| Dev hooks/filters | ❌ | ✅ documented | — | ✅ many filters |
+
+### Key takeaways from verification
+
+- **FluentAuth is the most direct threat** — its readme literally lists
+  "WP Login and Logout Redirect" as a plugin it replaces. But redirects are a
+  *side feature* in a security suite (2FA, social/magic login, login-attempt
+  limiting, audit logs). Its redirect rule engine matches **role + capability
+  only, AND-logic within a rule, first-match-wins** (`CustomAuthHandler::getDefaultLoginRedirectUrl`).
+  It has **no per-user targeting and no placeholders** — both easy wins for us.
+  It's fully free, monetized via the WPManageNinja ecosystem, not a pro tier.
+- **Every competitor has a rule engine; we have none.** That is the single
+  biggest gap and the spine of this roadmap.
+- Our **last-login column** is a genuine differentiator no competitor ships as
+  core — worth extending rather than abandoning.
+
+## 2. Product decisions (locked)
+
+- **Delivery:** Free plugin stays on wordpress.org. **Pro is a separate add-on
+  plugin distributed through Freemius** (licensing, payments, auto-updates).
+- **This phase:** spec only. Build order starts with the free rule engine.
+
+## 3. Free vs Pro feature split
+
+### Free (this plugin)
+- Ordered **rule engine**: match by **role / specific user / capability**, with
+  per-rule login + logout URL; first match wins; **default fallback** = the two
+  existing options (`wplalr_login_redirect`, `wplalr_logout_redirect`).
+- **Free placeholders:** `{{username}}`, `{{user_slug}}`, `{{website_url}}`.
+- **Loop detection** + URL validation hardening (same-site allowlist policy).
+- Keep + extend **Last Login** column.
+- **Extension points** (hooks/filters/JS slots) the Pro add-on plugs into.
+
+### Pro (separate Freemius add-on)
+- Dynamic placeholders `{{current_page}}` / `{{previous_page}}` (referrer).
+- **First-login-only** and **post-registration** redirects.
+- **WooCommerce-aware** rules (cart/checkout/My-Account) and **EDD** rules.
+- **Failed-login** redirect.
+- **Rule import/export** (JSON) for staging → production.
+- Extended analytics: last logout, login count, CSV export.
+- (Stretch epic, only if scope expands) content restriction + guest redirect.
+
+## 4. Data model
+
+Backward compatible — **no migration**. The two existing options become the
+default fallback; a new option holds the ordered rules.
+
+| Option key | Status | Purpose |
+|---|---|---|
+| `wplalr_login_redirect` | existing | Default login URL when no rule matches |
+| `wplalr_logout_redirect` | existing | Default logout URL when no rule matches |
+| `wplalr_redirect_rules` | **new** | Ordered array of rule objects |
+
+Rule object shape:
+
+```jsonc
+{
+  "id": "uuid",            // stable client-generated id
+  "enabled": true,
+  "label": "Editors → dashboard",
+  "match": {
+    "type": "role",        // free: "role" | "user" | "capability"
+    "values": ["editor"]   // role slugs | user IDs | capability names
+  },
+  "login_url": "https://example.com/dashboard/",
+  "logout_url": "https://example.com/bye/",
+
+  // Pro-only fields — stored if present, ignored by free runtime:
+  "first_login_only": false,
+  "wc_context": false
+}
+```
+
+## 5. Resolution algorithm (Redirection rewrite)
+
+`includes/Redirection.php` keeps hooking `login_redirect`,
+`woocommerce_login_redirect`, `wp_logout`, but resolves through a new
+`RuleEngine`:
+
+1. `do_action( 'wplalr/before_resolve', $event, $user )`.
+2. Iterate `wplalr_redirect_rules` in order; first rule whose `match` passes for
+   the current `$user` wins → take its `login_url`/`logout_url`.
+3. If none match, fall back to `wplalr_login_redirect` / `wplalr_logout_redirect`.
+4. If still empty, WP defaults (`admin_url()` / `home_url()`).
+5. Resolve placeholders: `apply_filters( 'wplalr/placeholders', $map, $user, $ctx )`.
+6. `apply_filters( 'wplalr/resolve_redirect', $url, $user, $rule, $event )`
+   (Pro overrides here for WC/EDD/referrer).
+7. Loop guard + `wp_validate_redirect()` against an allowlisted-host policy.
+
+Match logic mirrors the field-tested competitor model: AND within a rule's
+values is not needed (single match type per rule); `role`/`user`/`capability`
+checks against `$user->roles`, `$user->ID`, and `$user->allcaps`.
+
+## 6. REST API
+
+Extend `GET/POST wplalr/v1/settings` (cap `manage_options`) to:
+
+```jsonc
+{
+  "default_login_redirect": "…",   // maps to wplalr_login_redirect
+  "default_logout_redirect": "…",  // maps to wplalr_logout_redirect
+  "rules": [ /* rule objects */ ]
+}
+```
+
+- Server validates each rule: `match.type` ∈ allowlist; `match.values` validated
+  against `get_editable_roles()`, existing user IDs, or registered capabilities;
+  URLs sanitized with `esc_url_raw`.
+- Schema extensible for Pro: `apply_filters( 'wplalr/rest/rule_schema', $schema )`
+  and `apply_filters( 'wplalr/rest/settings_response', $data )`.
+
+## 7. React admin UI
+
+- New **Rules** tab/section: ordered list of `RuleRow` cards (match-type select,
+  multi-value selector, login URL, logout URL), add/remove/**drag-reorder**,
+  enable toggle, inline validation, placeholder helper text.
+- **Defaults / Fallback** card → the two existing options (unchanged UX for
+  users who never add a rule).
+- Pro fields surfaced via `wp.hooks` filters (e.g. `wplalr.ruleFields`,
+  `wplalr.tabs`); when free, render a locked/upsell state.
+- Replace the "Support Me" button with a Freemius-driven **Upgrade** CTA on free,
+  hidden when Pro is active.
+
+## 8. Free ⇄ Pro boundary (extension points)
+
+PHP filters/actions the Pro plugin hooks:
+
+- `wplalr/rule_match_types` — Pro registers advanced match types.
+- `wplalr/placeholders` — Pro adds `{{current_page}}`/`{{previous_page}}`.
+- `wplalr/resolve_redirect` — Pro overrides final URL (WC/EDD/referrer).
+- `wplalr/before_resolve`, `wplalr/after_resolve` — lifecycle.
+- `wplalr/rest/rule_schema`, `wplalr/rest/settings_response` — REST extension.
+
+JS: `@wordpress/hooks` filters as above so Pro can inject panels/fields without
+forking the free bundle.
+
+## 9. Freemius integration (free side)
+
+- Add Freemius SDK + `wplalr_fs()` initializer (plugin ID / public key / secret
+  from the Freemius dashboard), `has_premium_version` + `is_org_compliant`.
+- Free repo stays clean of paid code; Pro downloads as a separate plugin via
+  Freemius. Use `wplalr_fs()->can_use_premium_code()` only inside the Pro plugin.
+- Optional anonymous opt-in telemetry + upgrade/upsell surfaces.
+
+## 10. Build order
+
+**Free, phased:**
+1. Rule-engine data model + `RuleEngine` + `Redirection` rewrite + REST changes.
+2. React Rules UI (list, add/remove/reorder, validation) + Defaults card.
+3. Free placeholders resolver + loop detection + URL hardening.
+4. Freemius SDK (free side) + PHP/JS extension hooks scaffolding.
+
+**Pro add-on (separate plugin, after free lands):**
+5. Referrer placeholders → first-login/post-registration → WC/EDD → failed-login
+   → import/export → extended analytics.
+
+## 11. Open questions before coding phase 1
+
+- Confirm rule match is single-type-per-rule (simpler UI) vs multi-condition AND
+  (FluentAuth/LoginWP style). Recommendation: single type per rule for v1. 
+  Ans: Multi-condition AND (FluentAuth/LoginWP style)
+- Drag-reorder library: `@wordpress/components` has no DnD list; use
+  `@dnd-kit` or simple up/down buttons for v1. Recommendation: up/down buttons v1.
+  Ans: use `@dnd-kit`
+
+## 12. Detailed phases plan
+
+Decisions from §11 are now locked and reflected below:
+- **Rule matching = multi-condition AND** (FluentAuth/LoginWP style). A rule holds
+  a `conditions[]` array; **all** conditions must pass for the rule to match.
+- **Drag-reorder = `@dnd-kit`** in the React UI.
+
+This changes the rule object shape from §4 — the canonical multi-condition form is:
+
+```jsonc
+{
+  "id": "uuid",
+  "enabled": true,
+  "label": "Editors → dashboard",
+  "conditions": [                       // AND — all must match
+    { "type": "role",       "values": ["editor"] },
+    { "type": "capability", "values": ["edit_pages"] }
+  ],
+  "login_url": "https://example.com/dashboard/",
+  "logout_url": "https://example.com/bye/",
+  // Pro-only fields, stored if present, ignored by free runtime:
+  "first_login_only": false,
+  "wc_context": false
+}
+```
+
+`match.type`/`match.values` references elsewhere in this doc are superseded by
+`conditions[]`.
+
+---
+
+### Phase 1 — Rule-engine foundation (backend, no UI)
+
+**Goal:** rules resolve at login/logout via REST-managed data; installs with no
+rules behave exactly as today.
+
+- **Data model:** new option `wplalr_redirect_rules` (ordered array of rule
+  objects above). Keep `wplalr_login_redirect` / `wplalr_logout_redirect` as the
+  default fallback. No migration.
+- **`includes/RuleEngine.php` (new):** `resolve( $event, $user )` walks rules in
+  order, returns first rule where **every** condition passes
+  (`role`→`$user->roles`, `user`→`$user->ID`, `capability`→`$user->allcaps`);
+  empty `conditions` = matches everyone. Fires `wplalr/before_resolve`,
+  `wplalr/resolve_redirect`, `wplalr/after_resolve`.
+- **`includes/Redirection.php` (rewrite):** same hooks (`login_redirect`,
+  `woocommerce_login_redirect`, `wp_logout`); route through `RuleEngine` →
+  default options → WP default. Retain `wp_validate_redirect()`.
+- **`includes/REST/SettingsController.php` (extend):** GET/POST now read/write
+  `default_login_redirect`, `default_logout_redirect`, `rules[]`. Server-side
+  validation: condition `type` ∈ allowlist; `values` validated against
+  `get_editable_roles()` / existing user IDs / registered capabilities; URLs via
+  `esc_url_raw`. Pro-extension filters `wplalr/rest/rule_schema`,
+  `wplalr/rest/settings_response`.
+- **Acceptance:** rule created via REST redirects a matching user; non-matching
+  users fall through to defaults; `composer phpcs` + `php -l` clean.
+- **Not in scope:** UI, placeholders, Freemius.
+
+### Phase 2 — React Rules UI
+
+**Goal:** manage rules visually in the existing admin app.
+
+- New **Rules** section: list of `RuleRow` cards, each with a multi-condition
+  builder (add/remove condition rows: type select + multi-value selector),
+  login URL, logout URL, enable toggle.
+- **`@dnd-kit`** drag-to-reorder for the rule list; persists order to
+  `rules[]`.
+- **Defaults / Fallback** card → the two existing options (unchanged UX for
+  users who add no rules).
+- Inline validation, placeholder helper text. Pro fields surfaced via `wp.hooks`
+  filters (`wplalr.ruleFields`, `wplalr.tabs`) with a locked/upsell state.
+- **Acceptance:** create/edit/delete/reorder rules end-to-end; `npm run build`
+  + `npm run lint:js` clean.
+
+### Phase 3 — Free placeholders + hardening
+
+- **`includes/Placeholders.php` (new):** resolver for `{{username}}`,
+  `{{user_slug}}`, `{{website_url}}`, exposed via `wplalr/placeholders` filter so
+  Pro can add `{{current_page}}`/`{{previous_page}}`.
+- **Loop detection** + same-site allowlist URL policy in the resolve pipeline.
+- **Acceptance:** placeholders expand correctly; self-referential redirects are
+  caught; off-site URLs blocked unless allowlisted.
+
+### Phase 4 — Freemius (free side) + extension scaffolding
+
+- Freemius SDK + `wplalr_fs()` initializer (org-compliant, has-premium-version).
+- Finalize PHP filters (§8) + `@wordpress/hooks` JS slots so the Pro add-on
+  injects panels/fields without forking the free bundle.
+- Replace "Support Me" with a Freemius **Upgrade** CTA (hidden when Pro active).
+- **Acceptance:** free plugin loads with SDK, no paid code in the free repo;
+  extension points documented for the Pro plugin.
+
+### Phase 5 — Pro add-on (separate plugin, after free lands)
+
+Built as a separate Freemius-distributed plugin hooking the Phase 4 extension
+points, in this order: referrer placeholders → first-login / post-registration →
+WooCommerce / EDD-aware → failed-login redirect → rule import/export → extended
+analytics (last logout, login count, CSV).

--- a/docs/free-pro-roadmap.md
+++ b/docs/free-pro-roadmap.md
@@ -272,14 +272,15 @@ rules behave exactly as today.
 - **Acceptance:** placeholders expand correctly; self-referential redirects are
   caught; off-site URLs blocked unless allowlisted.
 
-### Phase 4 — Freemius (free side) + extension scaffolding
+### Phase 4 — extension scaffolding (done) · Freemius (deferred)
 
-- Freemius SDK + `wplalr_fs()` initializer (org-compliant, has-premium-version).
-- Finalize PHP filters (§8) + `@wordpress/hooks` JS slots so the Pro add-on
-  injects panels/fields without forking the free bundle.
-- Replace "Support Me" with a Freemius **Upgrade** CTA (hidden when Pro active).
-- **Acceptance:** free plugin loads with SDK, no paid code in the free repo;
-  extension points documented for the Pro plugin.
+**Done:** PHP filters (§8) + `@wordpress/hooks` JS slots so the Pro add-on
+injects routes/tabs/fields/match-types without forking the free bundle. Header
+actions are filterable (`wplalr.headerActions`) so an Upgrade CTA can be added
+later. All extension points documented in [`extensibility.md`](extensibility.md).
+
+**Deferred (by request):** Freemius SDK + `wplalr_fs()` initializer and the
+Freemius-driven Upgrade CTA — to be introduced later. "Support Me" stays for now.
 
 ### Phase 5 — Pro add-on (separate plugin, after free lands)
 

--- a/docs/free-pro-roadmap.md
+++ b/docs/free-pro-roadmap.md
@@ -104,13 +104,13 @@ Rule object shape:
 `woocommerce_login_redirect`, `wp_logout`, but resolves through a new
 `RuleEngine`:
 
-1. `do_action( 'wplalr/before_resolve', $event, $user )`.
+1. `do_action( 'wplalr_before_resolve', $event, $user )`.
 2. Iterate `wplalr_redirect_rules` in order; first rule whose `match` passes for
    the current `$user` wins → take its `login_url`/`logout_url`.
 3. If none match, fall back to `wplalr_login_redirect` / `wplalr_logout_redirect`.
 4. If still empty, WP defaults (`admin_url()` / `home_url()`).
-5. Resolve placeholders: `apply_filters( 'wplalr/placeholders', $map, $user, $ctx )`.
-6. `apply_filters( 'wplalr/resolve_redirect', $url, $user, $rule, $event )`
+5. Resolve placeholders: `apply_filters( 'wplalr_placeholders', $map, $user, $ctx )`.
+6. `apply_filters( 'wplalr_resolve_redirect', $url, $user, $rule, $event )`
    (Pro overrides here for WC/EDD/referrer).
 7. Loop guard + `wp_validate_redirect()` against an allowlisted-host policy.
 
@@ -133,8 +133,8 @@ Extend `GET/POST wplalr/v1/settings` (cap `manage_options`) to:
 - Server validates each rule: `match.type` ∈ allowlist; `match.values` validated
   against `get_editable_roles()`, existing user IDs, or registered capabilities;
   URLs sanitized with `esc_url_raw`.
-- Schema extensible for Pro: `apply_filters( 'wplalr/rest/rule_schema', $schema )`
-  and `apply_filters( 'wplalr/rest/settings_response', $data )`.
+- Schema extensible for Pro: `apply_filters( 'wplalr_rest_rule_schema', $schema )`
+  and `apply_filters( 'wplalr_rest_settings_response', $data )`.
 
 ## 7. React admin UI
 
@@ -143,8 +143,8 @@ Extend `GET/POST wplalr/v1/settings` (cap `manage_options`) to:
   enable toggle, inline validation, placeholder helper text.
 - **Defaults / Fallback** card → the two existing options (unchanged UX for
   users who never add a rule).
-- Pro fields surfaced via `wp.hooks` filters (e.g. `wplalr.ruleFields`,
-  `wplalr.tabs`); when free, render a locked/upsell state.
+- Pro fields surfaced via `wp.hooks` filters (e.g. `wplalr_rule_fields`,
+  `wplalr_tabs`); when free, render a locked/upsell state.
 - Replace the "Support Me" button with a Freemius-driven **Upgrade** CTA on free,
   hidden when Pro is active.
 
@@ -152,11 +152,11 @@ Extend `GET/POST wplalr/v1/settings` (cap `manage_options`) to:
 
 PHP filters/actions the Pro plugin hooks:
 
-- `wplalr/rule_match_types` — Pro registers advanced match types.
-- `wplalr/placeholders` — Pro adds `{{current_page}}`/`{{previous_page}}`.
-- `wplalr/resolve_redirect` — Pro overrides final URL (WC/EDD/referrer).
-- `wplalr/before_resolve`, `wplalr/after_resolve` — lifecycle.
-- `wplalr/rest/rule_schema`, `wplalr/rest/settings_response` — REST extension.
+- `wplalr_rule_match_types` — Pro registers advanced match types.
+- `wplalr_placeholders` — Pro adds `{{current_page}}`/`{{previous_page}}`.
+- `wplalr_resolve_redirect` — Pro overrides final URL (WC/EDD/referrer).
+- `wplalr_before_resolve`, `wplalr_after_resolve` — lifecycle.
+- `wplalr_rest_rule_schema`, `wplalr_rest_settings_response` — REST extension.
 
 JS: `@wordpress/hooks` filters as above so Pro can inject panels/fields without
 forking the free bundle.
@@ -232,8 +232,8 @@ rules behave exactly as today.
 - **`includes/RuleEngine.php` (new):** `resolve( $event, $user )` walks rules in
   order, returns first rule where **every** condition passes
   (`role`→`$user->roles`, `user`→`$user->ID`, `capability`→`$user->allcaps`);
-  empty `conditions` = matches everyone. Fires `wplalr/before_resolve`,
-  `wplalr/resolve_redirect`, `wplalr/after_resolve`.
+  empty `conditions` = matches everyone. Fires `wplalr_before_resolve`,
+  `wplalr_resolve_redirect`, `wplalr_after_resolve`.
 - **`includes/Redirection.php` (rewrite):** same hooks (`login_redirect`,
   `woocommerce_login_redirect`, `wp_logout`); route through `RuleEngine` →
   default options → WP default. Retain `wp_validate_redirect()`.
@@ -241,8 +241,8 @@ rules behave exactly as today.
   `default_login_redirect`, `default_logout_redirect`, `rules[]`. Server-side
   validation: condition `type` ∈ allowlist; `values` validated against
   `get_editable_roles()` / existing user IDs / registered capabilities; URLs via
-  `esc_url_raw`. Pro-extension filters `wplalr/rest/rule_schema`,
-  `wplalr/rest/settings_response`.
+  `esc_url_raw`. Pro-extension filters `wplalr_rest_rule_schema`,
+  `wplalr_rest_settings_response`.
 - **Acceptance:** rule created via REST redirects a matching user; non-matching
   users fall through to defaults; `composer phpcs` + `php -l` clean.
 - **Not in scope:** UI, placeholders, Freemius.
@@ -259,14 +259,14 @@ rules behave exactly as today.
 - **Defaults / Fallback** card → the two existing options (unchanged UX for
   users who add no rules).
 - Inline validation, placeholder helper text. Pro fields surfaced via `wp.hooks`
-  filters (`wplalr.ruleFields`, `wplalr.tabs`) with a locked/upsell state.
+  filters (`wplalr_rule_fields`, `wplalr_tabs`) with a locked/upsell state.
 - **Acceptance:** create/edit/delete/reorder rules end-to-end; `npm run build`
   + `npm run lint:js` clean.
 
 ### Phase 3 — Free placeholders + hardening
 
 - **`includes/Placeholders.php` (new):** resolver for `{{username}}`,
-  `{{user_slug}}`, `{{website_url}}`, exposed via `wplalr/placeholders` filter so
+  `{{user_slug}}`, `{{website_url}}`, exposed via `wplalr_placeholders` filter so
   Pro can add `{{current_page}}`/`{{previous_page}}`.
 - **Loop detection** + same-site allowlist URL policy in the resolve pipeline.
 - **Acceptance:** placeholders expand correctly; self-referential redirects are
@@ -276,7 +276,7 @@ rules behave exactly as today.
 
 **Done:** PHP filters (§8) + `@wordpress/hooks` JS slots so the Pro add-on
 injects routes/tabs/fields/match-types without forking the free bundle. Header
-actions are filterable (`wplalr.headerActions`) so an Upgrade CTA can be added
+actions are filterable (`wplalr_header_actions`) so an Upgrade CTA can be added
 later. All extension points documented in [`extensibility.md`](extensibility.md).
 
 **Deferred (by request):** Freemius SDK + `wplalr_fs()` initializer and the

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -78,11 +78,22 @@ class Assets {
 
 		wp_set_script_translations( 'wplalr-admin-page', 'wp-login-logout-redirect' );
 
+		if ( ! function_exists( 'get_editable_roles' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/user.php';
+		}
+
+		$roles = array();
+		foreach ( get_editable_roles() as $slug => $details ) {
+			$roles[ $slug ] = translate_user_role( $details['name'] );
+		}
+
 		wp_localize_script(
 			'wplalr-admin-page',
 			'wplalrAdmin',
 			array(
-				'homeUrl' => home_url(),
+				'homeUrl'  => home_url(),
+				'restRoot' => esc_url_raw( rest_url() ),
+				'roles'    => $roles,
 			)
 		);
 

--- a/includes/Placeholders.php
+++ b/includes/Placeholders.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Expands dynamic placeholders inside redirect URLs.
+ *
+ * Free tokens: {{username}}, {{user_slug}}, {{website_url}}. Pro extensions add
+ * tokens (e.g. {{current_page}}, {{previous_page}}) via the
+ * `wplalr/placeholders` filter.
+ */
+class Placeholders {
+
+	/**
+	 * Build the placeholder => replacement map for a user.
+	 *
+	 * @param \WP_User|null $user The user being redirected.
+	 * @return array
+	 */
+	public function get_map( $user = null ) {
+		$map = array(
+			'{{website_url}}' => home_url(),
+		);
+
+		if ( $user instanceof \WP_User && $user->exists() ) {
+			$map['{{username}}']  = $user->user_login;
+			$map['{{user_slug}}'] = $user->user_nicename;
+		}
+
+		/**
+		 * Filter the placeholder replacement map.
+		 *
+		 * Pro extensions hook here to register dynamic tokens such as
+		 * {{current_page}} and {{previous_page}}.
+		 *
+		 * @param array         $map  Map of `{{token}}` => replacement value.
+		 * @param \WP_User|null $user The user being redirected.
+		 */
+		return apply_filters( 'wplalr/placeholders', $map, $user );
+	}
+
+	/**
+	 * Replace placeholders in a URL.
+	 *
+	 * @param string        $url  The URL, possibly containing placeholders.
+	 * @param \WP_User|null $user The user being redirected.
+	 * @return string
+	 */
+	public function replace( $url, $user = null ) {
+		if ( empty( $url ) || strpos( $url, '{{' ) === false ) {
+			return $url;
+		}
+
+		return strtr( $url, $this->get_map( $user ) );
+	}
+}

--- a/includes/Placeholders.php
+++ b/includes/Placeholders.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Free tokens: {{username}}, {{user_slug}}, {{website_url}}. Pro extensions add
  * tokens (e.g. {{current_page}}, {{previous_page}}) via the
- * `wplalr/placeholders` filter.
+ * `wplalr_placeholders` filter.
  */
 class Placeholders {
 
@@ -40,7 +40,7 @@ class Placeholders {
 		 * @param array         $map  Map of `{{token}}` => replacement value.
 		 * @param \WP_User|null $user The user being redirected.
 		 */
-		return apply_filters( 'wplalr/placeholders', $map, $user );
+		return apply_filters( 'wplalr_placeholders', $map, $user );
 	}
 
 	/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -98,11 +98,11 @@ class SettingsController extends WP_REST_Controller {
 	 */
 	public function update_settings( $request ) {
 		if ( $request->has_param( 'wplalr_login_redirect' ) ) {
-			update_option( 'wplalr_login_redirect', esc_url_raw( $request->get_param( 'wplalr_login_redirect' ) ) );
+			update_option( 'wplalr_login_redirect', $this->sanitize_redirect_url( $request->get_param( 'wplalr_login_redirect' ) ) );
 		}
 
 		if ( $request->has_param( 'wplalr_logout_redirect' ) ) {
-			update_option( 'wplalr_logout_redirect', esc_url_raw( $request->get_param( 'wplalr_logout_redirect' ) ) );
+			update_option( 'wplalr_logout_redirect', $this->sanitize_redirect_url( $request->get_param( 'wplalr_logout_redirect' ) ) );
 		}
 
 		if ( $request->has_param( 'rules' ) ) {
@@ -110,6 +110,37 @@ class SettingsController extends WP_REST_Controller {
 		}
 
 		return $this->get_settings( $request );
+	}
+
+	/**
+	 * Sanitize a redirect URL while preserving {{placeholder}} tokens.
+	 *
+	 * Redirect URLs may contain placeholders such as `{{website_url}}` or
+	 * `{{username}}`. `esc_url_raw()` strips the curly braces (and can prepend a
+	 * scheme), which corrupts the template, so it is skipped when a placeholder is
+	 * present. The resolved URL is escaped and validated *after* placeholder
+	 * expansion at redirect time (see Redirection::resolve_login_redirect and
+	 * Redirection::redirect_after_logout), so the stored template stays intact.
+	 *
+	 * @param mixed $value Raw URL from the request.
+	 * @return string
+	 */
+	protected function sanitize_redirect_url( $value ) {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
+		$value = trim( $value );
+
+		if ( '' === $value ) {
+			return '';
+		}
+
+		if ( preg_match( '/\{\{\s*[a-z0-9_]+\s*\}\}/i', $value ) ) {
+			return sanitize_text_field( $value );
+		}
+
+		return esc_url_raw( $value );
 	}
 
 	/**
@@ -167,8 +198,8 @@ class SettingsController extends WP_REST_Controller {
 				'enabled'    => ! empty( $rule['enabled'] ),
 				'label'      => isset( $rule['label'] ) ? sanitize_text_field( $rule['label'] ) : '',
 				'conditions' => $conditions,
-				'login_url'  => isset( $rule['login_url'] ) ? esc_url_raw( $rule['login_url'] ) : '',
-				'logout_url' => isset( $rule['logout_url'] ) ? esc_url_raw( $rule['logout_url'] ) : '',
+				'login_url'  => isset( $rule['login_url'] ) ? $this->sanitize_redirect_url( $rule['login_url'] ) : '',
+				'logout_url' => isset( $rule['logout_url'] ) ? $this->sanitize_redirect_url( $rule['logout_url'] ) : '',
 			);
 
 			/**
@@ -283,12 +314,10 @@ class SettingsController extends WP_REST_Controller {
 					),
 				),
 				'login_url'  => array(
-					'type'   => 'string',
-					'format' => 'uri',
+					'type' => 'string',
 				),
 				'logout_url' => array(
-					'type'   => 'string',
-					'format' => 'uri',
+					'type' => 'string',
 				),
 			),
 		);
@@ -335,15 +364,13 @@ class SettingsController extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'wplalr_login_redirect'  => array(
-					'description' => __( 'URL to redirect the user to after a successful login.', 'wp-login-logout-redirect' ),
+					'description' => __( 'URL to redirect the user to after a successful login. May contain {{placeholder}} tokens.', 'wp-login-logout-redirect' ),
 					'type'        => 'string',
-					'format'      => 'uri',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'wplalr_logout_redirect' => array(
-					'description' => __( 'URL to redirect the user to after a successful logout.', 'wp-login-logout-redirect' ),
+					'description' => __( 'URL to redirect the user to after a successful logout. May contain {{placeholder}} tokens.', 'wp-login-logout-redirect' ),
 					'type'        => 'string',
-					'format'      => 'uri',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'rules'                  => array(

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use PluginizeLab\WpLoginLogoutRedirect\RuleEngine;
 use WP_REST_Controller;
 use WP_REST_Server;
 
@@ -74,7 +75,17 @@ class SettingsController extends WP_REST_Controller {
 		$settings = array(
 			'wplalr_login_redirect'  => get_option( 'wplalr_login_redirect', '' ),
 			'wplalr_logout_redirect' => get_option( 'wplalr_logout_redirect', '' ),
+			'rules'                  => array_values( (array) get_option( RuleEngine::OPTION_RULES, array() ) ),
 		);
+
+		/**
+		 * Filter the settings response payload.
+		 *
+		 * Pro extensions hook here to surface additional settings.
+		 *
+		 * @param array $settings The settings payload.
+		 */
+		$settings = apply_filters( 'wplalr/rest/settings_response', $settings );
 
 		return rest_ensure_response( $settings );
 	}
@@ -94,7 +105,162 @@ class SettingsController extends WP_REST_Controller {
 			update_option( 'wplalr_logout_redirect', esc_url_raw( $request->get_param( 'wplalr_logout_redirect' ) ) );
 		}
 
+		if ( $request->has_param( 'rules' ) ) {
+			update_option( RuleEngine::OPTION_RULES, $this->sanitize_rules( $request->get_param( 'rules' ) ) );
+		}
+
 		return $this->get_settings( $request );
+	}
+
+	/**
+	 * Sanitize and validate an array of redirect rules.
+	 *
+	 * @param mixed $raw Raw rules from the request.
+	 * @return array
+	 */
+	protected function sanitize_rules( $raw ) {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$valid_roles = array_keys( get_editable_roles() );
+		$clean       = array();
+
+		foreach ( $raw as $rule ) {
+			if ( ! is_array( $rule ) ) {
+				continue;
+			}
+
+			$raw_conditions = isset( $rule['conditions'] ) && is_array( $rule['conditions'] )
+				? $rule['conditions']
+				: array();
+
+			$conditions = array();
+
+			foreach ( $raw_conditions as $condition ) {
+				if ( ! is_array( $condition ) ) {
+					continue;
+				}
+
+				$type = isset( $condition['type'] ) ? sanitize_key( $condition['type'] ) : '';
+
+				if ( ! in_array( $type, array( 'role', 'user', 'capability' ), true ) ) {
+					continue;
+				}
+
+				$values = isset( $condition['values'] ) && is_array( $condition['values'] )
+					? $this->sanitize_condition_values( $type, $condition['values'], $valid_roles )
+					: array();
+
+				if ( empty( $values ) ) {
+					continue;
+				}
+
+				$conditions[] = array(
+					'type'   => $type,
+					'values' => $values,
+				);
+			}
+
+			$clean[] = array(
+				'id'         => isset( $rule['id'] ) && '' !== $rule['id'] ? sanitize_text_field( $rule['id'] ) : wp_generate_uuid4(),
+				'enabled'    => ! empty( $rule['enabled'] ),
+				'label'      => isset( $rule['label'] ) ? sanitize_text_field( $rule['label'] ) : '',
+				'conditions' => $conditions,
+				'login_url'  => isset( $rule['login_url'] ) ? esc_url_raw( $rule['login_url'] ) : '',
+				'logout_url' => isset( $rule['logout_url'] ) ? esc_url_raw( $rule['logout_url'] ) : '',
+			);
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Sanitize a condition's values against its type.
+	 *
+	 * @param string $type        Condition type: role|user|capability.
+	 * @param array  $values      Raw values.
+	 * @param array  $valid_roles List of valid role slugs.
+	 * @return array
+	 */
+	protected function sanitize_condition_values( $type, $values, $valid_roles ) {
+		$clean = array();
+
+		foreach ( $values as $value ) {
+			switch ( $type ) {
+				case 'role':
+					$role = sanitize_key( $value );
+					if ( in_array( $role, $valid_roles, true ) ) {
+						$clean[] = $role;
+					}
+					break;
+
+				case 'user':
+					$user_id = absint( $value );
+					if ( $user_id && get_user_by( 'id', $user_id ) ) {
+						$clean[] = (string) $user_id;
+					}
+					break;
+
+				case 'capability':
+					$cap = sanitize_key( $value );
+					if ( '' !== $cap ) {
+						$clean[] = $cap;
+					}
+					break;
+			}
+		}
+
+		return array_values( array_unique( $clean ) );
+	}
+
+	/**
+	 * Schema for a single redirect rule.
+	 *
+	 * @return array
+	 */
+	protected function get_rule_schema() {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'id'         => array( 'type' => 'string' ),
+				'enabled'    => array( 'type' => 'boolean' ),
+				'label'      => array( 'type' => 'string' ),
+				'conditions' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'type'   => array(
+								'type' => 'string',
+								'enum' => array( 'role', 'user', 'capability' ),
+							),
+							'values' => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+						),
+					),
+				),
+				'login_url'  => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+				'logout_url' => array(
+					'type'   => 'string',
+					'format' => 'uri',
+				),
+			),
+		);
+
+		/**
+		 * Filter the schema for a single redirect rule.
+		 *
+		 * Pro extensions hook here to register additional rule fields.
+		 *
+		 * @param array $schema The rule schema.
+		 */
+		return apply_filters( 'wplalr/rest/rule_schema', $schema );
 	}
 
 	/**
@@ -139,6 +305,12 @@ class SettingsController extends WP_REST_Controller {
 					'type'        => 'string',
 					'format'      => 'uri',
 					'context'     => array( 'view', 'edit' ),
+				),
+				'rules'                  => array(
+					'description' => __( 'Ordered redirect rules.', 'wp-login-logout-redirect' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => $this->get_rule_schema(),
 				),
 			),
 		);

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -123,7 +123,7 @@ class SettingsController extends WP_REST_Controller {
 			return array();
 		}
 
-		$valid_roles = array_keys( get_editable_roles() );
+		$valid_roles = array_keys( wp_roles()->roles );
 		$clean       = array();
 
 		foreach ( $raw as $rule ) {

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -85,7 +85,7 @@ class SettingsController extends WP_REST_Controller {
 		 *
 		 * @param array $settings The settings payload.
 		 */
-		$settings = apply_filters( 'wplalr/rest/settings_response', $settings );
+		$settings = apply_filters( 'wplalr_rest_settings_response', $settings );
 
 		return rest_ensure_response( $settings );
 	}
@@ -180,7 +180,7 @@ class SettingsController extends WP_REST_Controller {
 			 * @param array $clean_rule The sanitized rule.
 			 * @param array $rule       The raw rule from the request.
 			 */
-			$clean[] = apply_filters( 'wplalr/rest/sanitize_rule', $clean_rule, $rule );
+			$clean[] = apply_filters( 'wplalr_rest_sanitize_rule', $clean_rule, $rule );
 		}
 
 		return $clean;
@@ -196,12 +196,12 @@ class SettingsController extends WP_REST_Controller {
 		 * Filter the available rule condition match types.
 		 *
 		 * Pro extensions hook here to register custom match types; they should
-		 * also handle their sanitization via `wplalr/sanitize_condition_values`
-		 * and matching via `wplalr/match_condition`.
+		 * also handle their sanitization via `wplalr_sanitize_condition_values`
+		 * and matching via `wplalr_match_condition`.
 		 *
 		 * @param array $types Match type slugs.
 		 */
-		return apply_filters( 'wplalr/rule_match_types', array( 'role', 'user', 'capability' ) );
+		return apply_filters( 'wplalr_rule_match_types', array( 'role', 'user', 'capability' ) );
 	}
 
 	/**
@@ -220,7 +220,7 @@ class SettingsController extends WP_REST_Controller {
 			 * @param string $type   The condition type.
 			 * @param array  $values The raw values.
 			 */
-			return array_values( (array) apply_filters( 'wplalr/sanitize_condition_values', array(), $type, $values ) );
+			return array_values( (array) apply_filters( 'wplalr_sanitize_condition_values', array(), $type, $values ) );
 		}
 
 		$valid_roles = array_keys( wp_roles()->roles );
@@ -300,7 +300,7 @@ class SettingsController extends WP_REST_Controller {
 		 *
 		 * @param array $schema The rule schema.
 		 */
-		return apply_filters( 'wplalr/rest/rule_schema', $schema );
+		return apply_filters( 'wplalr_rest_rule_schema', $schema );
 	}
 
 	/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -123,7 +123,7 @@ class SettingsController extends WP_REST_Controller {
 			return array();
 		}
 
-		$valid_roles = array_keys( wp_roles()->roles );
+		$match_types = $this->get_match_types();
 		$clean       = array();
 
 		foreach ( $raw as $rule ) {
@@ -144,12 +144,12 @@ class SettingsController extends WP_REST_Controller {
 
 				$type = isset( $condition['type'] ) ? sanitize_key( $condition['type'] ) : '';
 
-				if ( ! in_array( $type, array( 'role', 'user', 'capability' ), true ) ) {
+				if ( ! in_array( $type, $match_types, true ) ) {
 					continue;
 				}
 
 				$values = isset( $condition['values'] ) && is_array( $condition['values'] )
-					? $this->sanitize_condition_values( $type, $condition['values'], $valid_roles )
+					? $this->sanitize_condition_values( $type, $condition['values'] )
 					: array();
 
 				if ( empty( $values ) ) {
@@ -162,7 +162,7 @@ class SettingsController extends WP_REST_Controller {
 				);
 			}
 
-			$clean[] = array(
+			$clean_rule = array(
 				'id'         => isset( $rule['id'] ) && '' !== $rule['id'] ? sanitize_text_field( $rule['id'] ) : wp_generate_uuid4(),
 				'enabled'    => ! empty( $rule['enabled'] ),
 				'label'      => isset( $rule['label'] ) ? sanitize_text_field( $rule['label'] ) : '',
@@ -170,21 +170,61 @@ class SettingsController extends WP_REST_Controller {
 				'login_url'  => isset( $rule['login_url'] ) ? esc_url_raw( $rule['login_url'] ) : '',
 				'logout_url' => isset( $rule['logout_url'] ) ? esc_url_raw( $rule['logout_url'] ) : '',
 			);
+
+			/**
+			 * Filter a single sanitized rule before it is stored.
+			 *
+			 * Pro extensions hook here to add their own sanitized fields
+			 * (e.g. first_login_only, wc_context) that the free plugin drops.
+			 *
+			 * @param array $clean_rule The sanitized rule.
+			 * @param array $rule       The raw rule from the request.
+			 */
+			$clean[] = apply_filters( 'wplalr/rest/sanitize_rule', $clean_rule, $rule );
 		}
 
 		return $clean;
 	}
 
 	/**
-	 * Sanitize a condition's values against its type.
+	 * The condition match types the rule engine understands.
 	 *
-	 * @param string $type        Condition type: role|user|capability.
-	 * @param array  $values      Raw values.
-	 * @param array  $valid_roles List of valid role slugs.
 	 * @return array
 	 */
-	protected function sanitize_condition_values( $type, $values, $valid_roles ) {
-		$clean = array();
+	protected function get_match_types() {
+		/**
+		 * Filter the available rule condition match types.
+		 *
+		 * Pro extensions hook here to register custom match types; they should
+		 * also handle their sanitization via `wplalr/sanitize_condition_values`
+		 * and matching via `wplalr/match_condition`.
+		 *
+		 * @param array $types Match type slugs.
+		 */
+		return apply_filters( 'wplalr/rule_match_types', array( 'role', 'user', 'capability' ) );
+	}
+
+	/**
+	 * Sanitize a condition's values against its type.
+	 *
+	 * @param string $type   Condition type: role|user|capability or a custom type.
+	 * @param array  $values Raw values.
+	 * @return array
+	 */
+	protected function sanitize_condition_values( $type, $values ) {
+		if ( ! in_array( $type, array( 'role', 'user', 'capability' ), true ) ) {
+			/**
+			 * Sanitize the values for a custom condition type.
+			 *
+			 * @param array  $clean  Sanitized values. Default empty array.
+			 * @param string $type   The condition type.
+			 * @param array  $values The raw values.
+			 */
+			return array_values( (array) apply_filters( 'wplalr/sanitize_condition_values', array(), $type, $values ) );
+		}
+
+		$valid_roles = array_keys( wp_roles()->roles );
+		$clean       = array();
 
 		foreach ( $values as $value ) {
 			switch ( $type ) {
@@ -233,7 +273,7 @@ class SettingsController extends WP_REST_Controller {
 						'properties' => array(
 							'type'   => array(
 								'type' => 'string',
-								'enum' => array( 'role', 'user', 'capability' ),
+								'enum' => array_values( $this->get_match_types() ),
 							),
 							'values' => array(
 								'type'  => 'array',

--- a/includes/Redirection.php
+++ b/includes/Redirection.php
@@ -125,7 +125,7 @@ class Redirection {
 		 * @param bool   $allow        Whether to allow the external host.
 		 * @param string $redirect_url The resolved logout URL.
 		 */
-		$allow_external = apply_filters( 'wplalr/allow_external_redirect', true, $redirect_url );
+		$allow_external = apply_filters( 'wplalr_allow_external_redirect', true, $redirect_url );
 
 		if ( $redirect_host && $allow_external ) {
 			add_filter(

--- a/includes/Redirection.php
+++ b/includes/Redirection.php
@@ -2,53 +2,118 @@
 
 namespace PluginizeLab\WpLoginLogoutRedirect;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Performs login/logout redirects, resolved through the rule engine.
+ */
 class Redirection {
+
+	/**
+	 * Rule engine instance.
+	 *
+	 * @var RuleEngine
+	 */
+	protected $rule_engine;
+
 	/**
 	 * The constructor.
+	 *
+	 * @param RuleEngine $rule_engine Rule engine instance.
 	 */
-	public function __construct() {
-        add_filter( 'login_redirect', array( $this, 'redirect_after_login' ) );
-        add_filter( 'woocommerce_login_redirect', array( $this, 'redirect_after_login' ) );
-        add_action( 'wp_logout', array( $this, 'redirect_after_logout' ) );
-    }
+	public function __construct( RuleEngine $rule_engine ) {
+		$this->rule_engine = $rule_engine;
 
-    /**
-     * Login redirect to user specific URL.
-     */
-    public function redirect_after_login( $redirect_to ) {
-        $redirect_to = wp_unslash( get_option( 'wplalr_login_redirect' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		add_filter( 'login_redirect', array( $this, 'login_redirect' ), 10, 3 );
+		add_filter( 'woocommerce_login_redirect', array( $this, 'woocommerce_login_redirect' ), 10, 2 );
+		add_action( 'wp_logout', array( $this, 'redirect_after_logout' ) );
+	}
 
-        if ( empty( $redirect_to ) ) {
-            $redirect_to = admin_url();
-        }
+	/**
+	 * Filter callback for the core `login_redirect` hook.
+	 *
+	 * @param string         $redirect_to           The redirect destination URL.
+	 * @param string         $requested_redirect_to The requested redirect destination URL.
+	 * @param \WP_User|mixed $user                  The logged-in user, or WP_Error.
+	 * @return string
+	 */
+	public function login_redirect( $redirect_to, $requested_redirect_to = '', $user = null ) {
+		return $this->resolve_login_redirect( $redirect_to, $user );
+	}
 
-        return wp_validate_redirect( $redirect_to );
-    }
+	/**
+	 * Filter callback for the `woocommerce_login_redirect` hook.
+	 *
+	 * @param string         $redirect The redirect destination URL.
+	 * @param \WP_User|mixed $user     The logged-in user.
+	 * @return string
+	 */
+	public function woocommerce_login_redirect( $redirect, $user = null ) {
+		return $this->resolve_login_redirect( $redirect, $user );
+	}
 
-    /**
-     * Logout redirect to user specific URL.
-     */
-    public function redirect_after_logout() {
-        $wplalr_logout_redirect = get_option( 'wplalr_logout_redirect' );
+	/**
+	 * Resolve and validate the login redirect URL.
+	 *
+	 * @param string         $fallback The hook's original redirect URL.
+	 * @param \WP_User|mixed $user     The logged-in user.
+	 * @return string
+	 */
+	protected function resolve_login_redirect( $fallback, $user ) {
+		if ( ! $user instanceof \WP_User ) {
+			$user = wp_get_current_user();
+		}
 
-        if ( empty( $wplalr_logout_redirect ) ) {
-            $wplalr_logout_redirect = home_url();
-        }
+		$redirect_to = $this->rule_engine->resolve( 'login', $user );
 
-        $redirect_url = esc_url( $wplalr_logout_redirect );
-        $redirect_host = wp_parse_url( $redirect_url, PHP_URL_HOST );
+		if ( empty( $redirect_to ) ) {
+			$redirect_to = wp_unslash( get_option( 'wplalr_login_redirect', '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		}
 
-        if ( $redirect_host ) {
-            add_filter(
-                'allowed_redirect_hosts',
-                function ( $hosts ) use ( $redirect_host ) {
+		if ( empty( $redirect_to ) ) {
+			$redirect_to = admin_url();
+		}
+
+		$safe_fallback = ! empty( $fallback ) ? $fallback : admin_url();
+
+		return wp_validate_redirect( $redirect_to, $safe_fallback );
+	}
+
+	/**
+	 * Logout redirect to the resolved URL.
+	 *
+	 * @param int $user_id The ID of the user that logged out.
+	 * @return void
+	 */
+	public function redirect_after_logout( $user_id = 0 ) {
+		$user = $user_id ? get_user_by( 'id', $user_id ) : wp_get_current_user();
+
+		$redirect_to = $this->rule_engine->resolve( 'logout', $user instanceof \WP_User ? $user : null );
+
+		if ( empty( $redirect_to ) ) {
+			$redirect_to = get_option( 'wplalr_logout_redirect', '' );
+		}
+
+		if ( empty( $redirect_to ) ) {
+			$redirect_to = home_url();
+		}
+
+		$redirect_url  = esc_url_raw( $redirect_to );
+		$redirect_host = wp_parse_url( $redirect_url, PHP_URL_HOST );
+
+		if ( $redirect_host ) {
+			add_filter(
+				'allowed_redirect_hosts',
+				function ( $hosts ) use ( $redirect_host ) {
 					$hosts[] = $redirect_host;
 					return $hosts;
-                }
-            );
-        }
+				}
+			);
+		}
 
-        wp_safe_redirect( $redirect_url );
-        exit();
-    }
+		wp_safe_redirect( $redirect_url );
+		exit();
+	}
 }

--- a/includes/Redirection.php
+++ b/includes/Redirection.php
@@ -19,12 +19,21 @@ class Redirection {
 	protected $rule_engine;
 
 	/**
+	 * Placeholder resolver instance.
+	 *
+	 * @var Placeholders
+	 */
+	protected $placeholders;
+
+	/**
 	 * The constructor.
 	 *
-	 * @param RuleEngine $rule_engine Rule engine instance.
+	 * @param RuleEngine   $rule_engine  Rule engine instance.
+	 * @param Placeholders $placeholders Placeholder resolver instance.
 	 */
-	public function __construct( RuleEngine $rule_engine ) {
-		$this->rule_engine = $rule_engine;
+	public function __construct( RuleEngine $rule_engine, Placeholders $placeholders ) {
+		$this->rule_engine  = $rule_engine;
+		$this->placeholders = $placeholders;
 
 		add_filter( 'login_redirect', array( $this, 'login_redirect' ), 10, 3 );
 		add_filter( 'woocommerce_login_redirect', array( $this, 'woocommerce_login_redirect' ), 10, 2 );
@@ -72,7 +81,9 @@ class Redirection {
 			$redirect_to = wp_unslash( get_option( 'wplalr_login_redirect', '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
 
-		if ( empty( $redirect_to ) ) {
+		$redirect_to = $this->placeholders->replace( $redirect_to, $user );
+
+		if ( empty( $redirect_to ) || $this->is_redirect_loop( $redirect_to, 'login' ) ) {
 			$redirect_to = admin_url();
 		}
 
@@ -89,21 +100,34 @@ class Redirection {
 	 */
 	public function redirect_after_logout( $user_id = 0 ) {
 		$user = $user_id ? get_user_by( 'id', $user_id ) : wp_get_current_user();
+		$user = $user instanceof \WP_User ? $user : null;
 
-		$redirect_to = $this->rule_engine->resolve( 'logout', $user instanceof \WP_User ? $user : null );
+		$redirect_to = $this->rule_engine->resolve( 'logout', $user );
 
 		if ( empty( $redirect_to ) ) {
 			$redirect_to = get_option( 'wplalr_logout_redirect', '' );
 		}
 
-		if ( empty( $redirect_to ) ) {
+		$redirect_to = $this->placeholders->replace( $redirect_to, $user );
+
+		if ( empty( $redirect_to ) || $this->is_redirect_loop( $redirect_to, 'logout' ) ) {
 			$redirect_to = home_url();
 		}
 
 		$redirect_url  = esc_url_raw( $redirect_to );
 		$redirect_host = wp_parse_url( $redirect_url, PHP_URL_HOST );
 
-		if ( $redirect_host ) {
+		/**
+		 * Whether to allow redirecting to the admin-configured external host.
+		 *
+		 * Return false to enforce a same-site-only policy on logout.
+		 *
+		 * @param bool   $allow        Whether to allow the external host.
+		 * @param string $redirect_url The resolved logout URL.
+		 */
+		$allow_external = apply_filters( 'wplalr/allow_external_redirect', true, $redirect_url );
+
+		if ( $redirect_host && $allow_external ) {
 			add_filter(
 				'allowed_redirect_hosts',
 				function ( $hosts ) use ( $redirect_host ) {
@@ -113,7 +137,65 @@ class Redirection {
 			);
 		}
 
-		wp_safe_redirect( $redirect_url );
+		wp_safe_redirect( wp_validate_redirect( $redirect_url, home_url() ) );
 		exit();
+	}
+
+	/**
+	 * Detect a redirect that would loop.
+	 *
+	 * Guards against sending users back to the login screen on login, or to the
+	 * exact URL they are already on.
+	 *
+	 * @param string $url   The resolved redirect URL.
+	 * @param string $event 'login' or 'logout'.
+	 * @return bool
+	 */
+	protected function is_redirect_loop( $url, $event ) {
+		if ( empty( $url ) ) {
+			return false;
+		}
+
+		$target_path = $this->normalize_path( wp_parse_url( $url, PHP_URL_PATH ) );
+
+		if ( '' === $target_path ) {
+			return false;
+		}
+
+		// On login, never bounce back to the login screen.
+		if ( 'login' === $event ) {
+			$login_path = $this->normalize_path( wp_parse_url( wp_login_url(), PHP_URL_PATH ) );
+
+			if ( '' !== $login_path && $target_path === $login_path ) {
+				return true;
+			}
+		}
+
+		// Never redirect to the exact URL currently being requested.
+		if ( isset( $_SERVER['REQUEST_URI'] ) ) {
+			$current_path = $this->normalize_path(
+				wp_parse_url( esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ), PHP_URL_PATH )
+			);
+
+			if ( '' !== $current_path && $target_path === $current_path ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Normalize a URL path for comparison.
+	 *
+	 * @param string|null $path The path component.
+	 * @return string
+	 */
+	protected function normalize_path( $path ) {
+		if ( empty( $path ) ) {
+			return '';
+		}
+
+		return untrailingslashit( $path );
 	}
 }

--- a/includes/RuleEngine.php
+++ b/includes/RuleEngine.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace PluginizeLab\WpLoginLogoutRedirect;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Resolves login/logout redirect URLs from the ordered rule set.
+ *
+ * A rule matches when *every* one of its conditions passes (AND logic). Within
+ * a single condition, any one of its values is enough (OR logic). Rules are
+ * evaluated in order and the first matching, enabled rule with a URL for the
+ * requested event wins. When nothing matches, the caller falls back to the
+ * legacy global options.
+ */
+class RuleEngine {
+
+	/**
+	 * Option key holding the ordered array of rule objects.
+	 *
+	 * @var string
+	 */
+	const OPTION_RULES = 'wplalr_redirect_rules';
+
+	/**
+	 * Get the stored rules.
+	 *
+	 * @return array
+	 */
+	public function get_rules() {
+		$rules = get_option( self::OPTION_RULES, array() );
+
+		return is_array( $rules ) ? array_values( $rules ) : array();
+	}
+
+	/**
+	 * Resolve the redirect URL for a given event and user.
+	 *
+	 * @param string        $event 'login' or 'logout'.
+	 * @param \WP_User|null $user  The user being redirected.
+	 * @return string The resolved URL, or an empty string when no rule applies.
+	 */
+	public function resolve( $event, $user = null ) {
+		do_action( 'wplalr/before_resolve', $event, $user );
+
+		$url     = '';
+		$matched = null;
+		$url_key = 'logout' === $event ? 'logout_url' : 'login_url';
+
+		foreach ( $this->get_rules() as $rule ) {
+			if ( ! is_array( $rule ) || empty( $rule['enabled'] ) ) {
+				continue;
+			}
+
+			if ( ! $this->matches( $rule, $user ) ) {
+				continue;
+			}
+
+			if ( ! empty( $rule[ $url_key ] ) ) {
+				$url     = (string) $rule[ $url_key ];
+				$matched = $rule;
+				break;
+			}
+		}
+
+		/**
+		 * Filter the resolved redirect URL before validation.
+		 *
+		 * Pro extensions hook here to override the destination (referrer
+		 * placeholders, WooCommerce/EDD-aware flows, etc.).
+		 *
+		 * @param string        $url     The resolved URL (may be empty).
+		 * @param \WP_User|null $user    The user being redirected.
+		 * @param array|null    $matched The matched rule, or null.
+		 * @param string        $event   'login' or 'logout'.
+		 */
+		$url = apply_filters( 'wplalr/resolve_redirect', $url, $user, $matched, $event );
+
+		do_action( 'wplalr/after_resolve', $url, $event, $user, $matched );
+
+		return $url;
+	}
+
+	/**
+	 * Whether every condition of a rule passes for the given user.
+	 *
+	 * A rule with no conditions matches everyone.
+	 *
+	 * @param array         $rule The rule object.
+	 * @param \WP_User|null $user The user being redirected.
+	 * @return bool
+	 */
+	protected function matches( $rule, $user ) {
+		$conditions = isset( $rule['conditions'] ) && is_array( $rule['conditions'] )
+			? $rule['conditions']
+			: array();
+
+		if ( empty( $conditions ) ) {
+			return true;
+		}
+
+		if ( ! $user instanceof \WP_User || ! $user->exists() ) {
+			return false;
+		}
+
+		foreach ( $conditions as $condition ) {
+			if ( ! is_array( $condition ) || ! $this->condition_passes( $condition, $user ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether a single condition passes for the user (OR within its values).
+	 *
+	 * @param array    $condition The condition object.
+	 * @param \WP_User $user      The user being redirected.
+	 * @return bool
+	 */
+	protected function condition_passes( $condition, \WP_User $user ) {
+		$type   = isset( $condition['type'] ) ? $condition['type'] : '';
+		$values = isset( $condition['values'] ) && is_array( $condition['values'] )
+			? $condition['values']
+			: array();
+
+		if ( empty( $values ) ) {
+			return false;
+		}
+
+		switch ( $type ) {
+			case 'role':
+				return (bool) array_intersect( array_map( 'strval', $values ), (array) $user->roles );
+
+			case 'user':
+				return in_array( (string) $user->ID, array_map( 'strval', $values ), true );
+
+			case 'capability':
+				foreach ( $values as $cap ) {
+					if ( $user->has_cap( (string) $cap ) ) {
+						return true;
+					}
+				}
+
+				return false;
+
+			default:
+				return false;
+		}
+	}
+}

--- a/includes/RuleEngine.php
+++ b/includes/RuleEngine.php
@@ -43,7 +43,7 @@ class RuleEngine {
 	 * @return string The resolved URL, or an empty string when no rule applies.
 	 */
 	public function resolve( $event, $user = null ) {
-		do_action( 'wplalr/before_resolve', $event, $user );
+		do_action( 'wplalr_before_resolve', $event, $user );
 
 		$url     = '';
 		$matched = null;
@@ -76,9 +76,9 @@ class RuleEngine {
 		 * @param array|null    $matched The matched rule, or null.
 		 * @param string        $event   'login' or 'logout'.
 		 */
-		$url = apply_filters( 'wplalr/resolve_redirect', $url, $user, $matched, $event );
+		$url = apply_filters( 'wplalr_resolve_redirect', $url, $user, $matched, $event );
 
-		do_action( 'wplalr/after_resolve', $url, $event, $user, $matched );
+		do_action( 'wplalr_after_resolve', $url, $event, $user, $matched );
 
 		return $url;
 	}
@@ -152,14 +152,14 @@ class RuleEngine {
 				 * Resolve a match for a condition type the free plugin does not handle.
 				 *
 				 * Pro extensions hook here to evaluate custom match types registered
-				 * via the `wplalr/rule_match_types` filter.
+				 * via the `wplalr_rule_match_types` filter.
 				 *
 				 * @param bool     $matched Whether the condition matches. Default false.
 				 * @param string   $type    The condition type.
 				 * @param array    $values  The condition values.
 				 * @param \WP_User $user    The user being redirected.
 				 */
-				return (bool) apply_filters( 'wplalr/match_condition', false, $type, $values, $user );
+				return (bool) apply_filters( 'wplalr_match_condition', false, $type, $values, $user );
 		}
 	}
 }

--- a/includes/RuleEngine.php
+++ b/includes/RuleEngine.php
@@ -148,7 +148,18 @@ class RuleEngine {
 				return false;
 
 			default:
-				return false;
+				/**
+				 * Resolve a match for a condition type the free plugin does not handle.
+				 *
+				 * Pro extensions hook here to evaluate custom match types registered
+				 * via the `wplalr/rule_match_types` filter.
+				 *
+				 * @param bool     $matched Whether the condition matches. Default false.
+				 * @param string   $type    The condition type.
+				 * @param array    $values  The condition values.
+				 * @param \WP_User $user    The user being redirected.
+				 */
+				return (bool) apply_filters( 'wplalr/match_condition', false, $type, $values, $user );
 		}
 	}
 }

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -21,8 +21,23 @@ class Settings {
 			'manage_options',
 			'wplalr_login_logout_redirect',
 			array( $this, 'login_logout_redirect_settings_form' ),
-			'dashicons-randomize'
+			$this->get_menu_icon()
 		);
+	}
+
+	/**
+	 * The admin menu icon, as a base64-encoded SVG data URI.
+	 *
+	 * Uses the Heroicons (MIT) "Squares2x2" outline glyph to match the icon
+	 * shown in the settings page header. WordPress renders menu SVGs on a dark
+	 * background without recoloring, so the default admin icon gray is baked in.
+	 *
+	 * @return string
+	 */
+	protected function get_menu_icon() {
+		$svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="#a7aaad"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>';
+
+		return 'data:image/svg+xml;base64,' . base64_encode( $svg ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	/**

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -21,23 +21,8 @@ class Settings {
 			'manage_options',
 			'wplalr_login_logout_redirect',
 			array( $this, 'login_logout_redirect_settings_form' ),
-			$this->get_menu_icon()
+			'dashicons-randomize'
 		);
-	}
-
-	/**
-	 * The admin menu icon, as a base64-encoded SVG data URI.
-	 *
-	 * Uses the Heroicons (MIT) "Squares2x2" outline glyph to match the icon
-	 * shown in the settings page header. WordPress renders menu SVGs on a dark
-	 * background without recoloring, so the default admin icon gray is baked in.
-	 *
-	 * @return string
-	 */
-	protected function get_menu_icon() {
-		$svg = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="#a7aaad"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25A2.25 2.25 0 0 1 13.5 18v-2.25Z"/></svg>';
-
-		return 'data:image/svg+xml;base64,' . base64_encode( $svg ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 	}
 
 	/**

--- a/includes/WpLoginLogoutRedirect.php
+++ b/includes/WpLoginLogoutRedirect.php
@@ -174,7 +174,8 @@ final class WpLoginLogoutRedirect {
         $this->container['scripts'] = new Assets();
         $this->container['admin_settings'] = new Settings();
         $this->container['admin_settings_controller'] = new REST\SettingsController();
-        $this->container['redirection'] = new Redirection();
+        $this->container['rule_engine'] = new RuleEngine();
+        $this->container['redirection'] = new Redirection( $this->container['rule_engine'] );
         $this->container['user_login_time'] = new UserLoginTime();
     }
 

--- a/includes/WpLoginLogoutRedirect.php
+++ b/includes/WpLoginLogoutRedirect.php
@@ -175,7 +175,8 @@ final class WpLoginLogoutRedirect {
         $this->container['admin_settings'] = new Settings();
         $this->container['admin_settings_controller'] = new REST\SettingsController();
         $this->container['rule_engine'] = new RuleEngine();
-        $this->container['redirection'] = new Redirection( $this->container['rule_engine'] );
+        $this->container['placeholders'] = new Placeholders();
+        $this->container['redirection'] = new Redirection( $this->container['rule_engine'], $this->container['placeholders'] );
         $this->container['user_login_time'] = new UserLoginTime();
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "3.1.7",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@dnd-kit/core": "^6.3.1",
+				"@dnd-kit/sortable": "^8.0.0",
+				"@dnd-kit/utilities": "^3.2.2",
 				"@heroicons/react": "^2.2.0",
 				"@wordpress/api-fetch": "^7.0.0",
 				"@wordpress/components": "^33.1.0",
@@ -16,6 +19,7 @@
 				"@wordpress/element": "^6.0.0",
 				"@wordpress/i18n": "^6.0.0",
 				"@wordpress/notices": "^5.0.0",
+				"@wordpress/url": "^4.48.1",
 				"react-router-dom": "^6.23.1"
 			},
 			"devDependencies": {
@@ -2417,6 +2421,59 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/@dnd-kit/accessibility": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+			"integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/core": {
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+			"integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/accessibility": "^3.1.1",
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/sortable": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+			"integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@dnd-kit/utilities": "^3.2.2",
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"@dnd-kit/core": "^6.1.0",
+				"react": ">=16.8.0"
+			}
+		},
+		"node_modules/@dnd-kit/utilities": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+			"integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0"
 			}
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
 				"@wordpress/components": "^33.1.0",
 				"@wordpress/data": "^10.0.0",
 				"@wordpress/element": "^6.0.0",
+				"@wordpress/hooks": "^4.48.1",
 				"@wordpress/i18n": "^6.0.0",
 				"@wordpress/notices": "^5.0.0",
 				"@wordpress/url": "^4.48.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/components": "^33.1.0",
 		"@wordpress/data": "^10.0.0",
 		"@wordpress/element": "^6.0.0",
+		"@wordpress/hooks": "^4.48.1",
 		"@wordpress/i18n": "^6.0.0",
 		"@wordpress/notices": "^5.0.0",
 		"@wordpress/url": "^4.48.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
 	"author": "Aminur Islam",
 	"license": "GPL-2.0-or-later",
 	"dependencies": {
+		"@dnd-kit/core": "^6.3.1",
+		"@dnd-kit/sortable": "^8.0.0",
+		"@dnd-kit/utilities": "^3.2.2",
 		"@heroicons/react": "^2.2.0",
 		"@wordpress/api-fetch": "^7.0.0",
 		"@wordpress/components": "^33.1.0",
@@ -31,6 +34,7 @@
 		"@wordpress/element": "^6.0.0",
 		"@wordpress/i18n": "^6.0.0",
 		"@wordpress/notices": "^5.0.0",
+		"@wordpress/url": "^4.48.1",
 		"react-router-dom": "^6.23.1"
 	},
 	"devDependencies": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -135,4 +135,8 @@
     <rule ref="Squiz.PHP.CommentedOutCode.Found">
         <severity>0</severity>
     </rule>
+    <!-- Allow namespaced "wplalr/..." hook names used by the extension API. -->
+    <rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores">
+        <severity>0</severity>
+    </rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -135,8 +135,4 @@
     <rule ref="Squiz.PHP.CommentedOutCode.Found">
         <severity>0</severity>
     </rule>
-    <!-- Allow namespaced "wplalr/..." hook names used by the extension API. -->
-    <rule ref="WordPress.NamingConventions.ValidHookName.UseUnderscores">
-        <severity>0</severity>
-    </rule>
 </ruleset>

--- a/src/admin.js
+++ b/src/admin.js
@@ -15,6 +15,7 @@ import './components/LayoutStyles.css';
 import { SettingsProvider } from './context/SettingsContext';
 import Layout from './components/Layout';
 import RedirectSettings from './components/RedirectSettings';
+import RulesSettings from './components/RulesSettings';
 
 const App = () => (
 	<SettingsProvider>
@@ -22,6 +23,7 @@ const App = () => (
 			<Routes>
 				<Route path="/" element={ <Layout /> }>
 					<Route index element={ <RedirectSettings /> } />
+					<Route path="rules" element={ <RulesSettings /> } />
 				</Route>
 			</Routes>
 		</Router>

--- a/src/admin.js
+++ b/src/admin.js
@@ -9,6 +9,11 @@ import { createRoot } from '@wordpress/element';
 import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import './components/LayoutStyles.css';
@@ -17,18 +22,31 @@ import Layout from './components/Layout';
 import RedirectSettings from './components/RedirectSettings';
 import RulesSettings from './components/RulesSettings';
 
-const App = () => (
-	<SettingsProvider>
-		<Router>
-			<Routes>
-				<Route path="/" element={ <Layout /> }>
-					<Route index element={ <RedirectSettings /> } />
-					<Route path="rules" element={ <RulesSettings /> } />
-				</Route>
-			</Routes>
-		</Router>
-	</SettingsProvider>
-);
+const App = () => {
+	// Pro extensions add routes here via the `wplalr.routes` filter.
+	const routes = applyFilters( 'wplalr.routes', [
+		{ path: 'rules', element: <RulesSettings /> },
+	] );
+
+	return (
+		<SettingsProvider>
+			<Router>
+				<Routes>
+					<Route path="/" element={ <Layout /> }>
+						<Route index element={ <RedirectSettings /> } />
+						{ routes.map( ( { path, element } ) => (
+							<Route
+								key={ path }
+								path={ path }
+								element={ element }
+							/>
+						) ) }
+					</Route>
+				</Routes>
+			</Router>
+		</SettingsProvider>
+	);
+};
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	const container = document.getElementById( 'wplalr-settings' );

--- a/src/admin.js
+++ b/src/admin.js
@@ -23,8 +23,8 @@ import RedirectSettings from './components/RedirectSettings';
 import RulesSettings from './components/RulesSettings';
 
 const App = () => {
-	// Pro extensions add routes here via the `wplalr.routes` filter.
-	const routes = applyFilters( 'wplalr.routes', [
+	// Pro extensions add routes here via the `wplalr_routes` filter.
+	const routes = applyFilters( 'wplalr_routes', [
 		{ path: 'rules', element: <RulesSettings /> },
 	] );
 

--- a/src/components/ConditionRow.js
+++ b/src/components/ConditionRow.js
@@ -1,0 +1,55 @@
+import { __ } from '@wordpress/i18n';
+import { SelectControl, Button } from '@wordpress/components';
+
+import ConditionValueControl from './ConditionValueControl';
+import { TrashIcon } from './icons';
+
+const TYPE_OPTIONS = [
+	{ label: __( 'Role', 'wp-login-logout-redirect' ), value: 'role' },
+	{ label: __( 'Specific user', 'wp-login-logout-redirect' ), value: 'user' },
+	{
+		label: __( 'Capability', 'wp-login-logout-redirect' ),
+		value: 'capability',
+	},
+];
+
+/**
+ * A single condition row inside a rule: type selector + value selector.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.condition The condition object.
+ * @param {Function} props.onChange  Receives a partial patch for the condition.
+ * @param {Function} props.onRemove  Removes this condition.
+ */
+const ConditionRow = ( { condition, onChange, onRemove } ) => {
+	return (
+		<div className="wplalr-condition-row">
+			<div className="wplalr-condition-type">
+				<SelectControl
+					label={ __( 'When', 'wp-login-logout-redirect' ) }
+					value={ condition.type }
+					options={ TYPE_OPTIONS }
+					onChange={ ( type ) => onChange( { type, values: [] } ) }
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				/>
+			</div>
+			<div className="wplalr-condition-values">
+				<ConditionValueControl
+					type={ condition.type }
+					values={ condition.values ?? [] }
+					onChange={ ( values ) => onChange( { values } ) }
+				/>
+			</div>
+			<Button
+				className="wplalr-condition-remove"
+				icon={ <TrashIcon /> }
+				label={ __( 'Remove condition', 'wp-login-logout-redirect' ) }
+				onClick={ onRemove }
+				isDestructive
+			/>
+		</div>
+	);
+};
+
+export default ConditionRow;

--- a/src/components/ConditionRow.js
+++ b/src/components/ConditionRow.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { SelectControl, Button } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 
 import ConditionValueControl from './ConditionValueControl';
 import { TrashIcon } from './icons';
@@ -22,13 +23,16 @@ const TYPE_OPTIONS = [
  * @param {Function} props.onRemove  Removes this condition.
  */
 const ConditionRow = ( { condition, onChange, onRemove } ) => {
+	// Pro extensions register additional match types here.
+	const typeOptions = applyFilters( 'wplalr.conditionTypes', TYPE_OPTIONS );
+
 	return (
 		<div className="wplalr-condition-row">
 			<div className="wplalr-condition-type">
 				<SelectControl
 					label={ __( 'When', 'wp-login-logout-redirect' ) }
 					value={ condition.type }
-					options={ TYPE_OPTIONS }
+					options={ typeOptions }
 					onChange={ ( type ) => onChange( { type, values: [] } ) }
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom

--- a/src/components/ConditionRow.js
+++ b/src/components/ConditionRow.js
@@ -24,7 +24,7 @@ const TYPE_OPTIONS = [
  */
 const ConditionRow = ( { condition, onChange, onRemove } ) => {
 	// Pro extensions register additional match types here.
-	const typeOptions = applyFilters( 'wplalr.conditionTypes', TYPE_OPTIONS );
+	const typeOptions = applyFilters( 'wplalr_condition_types', TYPE_OPTIONS );
 
 	return (
 		<div className="wplalr-condition-row">

--- a/src/components/ConditionValueControl.js
+++ b/src/components/ConditionValueControl.js
@@ -3,6 +3,7 @@ import { FormTokenField } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
+import { applyFilters } from '@wordpress/hooks';
 
 const ROLES = window.wplalrAdmin?.roles ?? {};
 
@@ -25,6 +26,17 @@ const parseUserId = ( label ) => {
  * @param {Function} props.onChange Receives the next values array.
  */
 const ConditionValueControl = ( { type, values, onChange } ) => {
+	// Pro extensions render value controls for their custom match types.
+	const custom = applyFilters( 'wplalr.conditionValueControl', null, {
+		type,
+		values,
+		onChange,
+	} );
+
+	if ( custom ) {
+		return custom;
+	}
+
 	if ( type === 'role' ) {
 		const nameBySlug = ROLES;
 		const slugByName = Object.fromEntries(

--- a/src/components/ConditionValueControl.js
+++ b/src/components/ConditionValueControl.js
@@ -27,7 +27,7 @@ const parseUserId = ( label ) => {
  */
 const ConditionValueControl = ( { type, values, onChange } ) => {
 	// Pro extensions render value controls for their custom match types.
-	const custom = applyFilters( 'wplalr.conditionValueControl', null, {
+	const custom = applyFilters( 'wplalr_condition_value_control', null, {
 		type,
 		values,
 		onChange,

--- a/src/components/ConditionValueControl.js
+++ b/src/components/ConditionValueControl.js
@@ -1,0 +1,168 @@
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { FormTokenField } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+
+const ROLES = window.wplalrAdmin?.roles ?? {};
+
+const formatUserLabel = ( name, id ) => `${ name } (#${ id })`;
+const parseUserId = ( label ) => {
+	const match = /\(#(\d+)\)\s*$/.exec( label );
+	return match ? match[ 1 ] : '';
+};
+
+/**
+ * Renders the value selector for a single condition, switching on its type.
+ *
+ * - role: token field backed by the site's editable roles.
+ * - capability: free-text token field.
+ * - user: token field with debounced async user search.
+ *
+ * @param {Object}   props
+ * @param {string}   props.type     Condition type: role|user|capability.
+ * @param {string[]} props.values   Stored values (role slugs, user IDs, caps).
+ * @param {Function} props.onChange Receives the next values array.
+ */
+const ConditionValueControl = ( { type, values, onChange } ) => {
+	if ( type === 'role' ) {
+		const nameBySlug = ROLES;
+		const slugByName = Object.fromEntries(
+			Object.entries( ROLES ).map( ( [ slug, name ] ) => [ name, slug ] )
+		);
+
+		return (
+			<FormTokenField
+				label={ __( 'Roles', 'wp-login-logout-redirect' ) }
+				value={ values.map( ( slug ) => nameBySlug[ slug ] ?? slug ) }
+				suggestions={ Object.values( nameBySlug ) }
+				onChange={ ( tokens ) =>
+					onChange(
+						tokens
+							.map( ( token ) => slugByName[ token ] ?? token )
+							.filter( ( slug ) => nameBySlug[ slug ] )
+					)
+				}
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				__experimentalExpandOnFocus
+			/>
+		);
+	}
+
+	if ( type === 'capability' ) {
+		return (
+			<FormTokenField
+				label={ __( 'Capabilities', 'wp-login-logout-redirect' ) }
+				value={ values }
+				onChange={ onChange }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+			/>
+		);
+	}
+
+	return <UserValueControl values={ values } onChange={ onChange } />;
+};
+
+/**
+ * User token field with debounced search and label caching.
+ *
+ * @param {Object}   props
+ * @param {string[]} props.values   Stored user IDs (as strings).
+ * @param {Function} props.onChange Receives the next array of user IDs.
+ */
+const UserValueControl = ( { values, onChange } ) => {
+	const [ labelById, setLabelById ] = useState( {} );
+	const [ suggestions, setSuggestions ] = useState( [] );
+	const debounceRef = useRef();
+
+	// Resolve labels for already-stored IDs that we have not seen yet.
+	useEffect( () => {
+		const missing = values.filter( ( id ) => ! labelById[ id ] );
+
+		if ( missing.length === 0 ) {
+			return;
+		}
+
+		apiFetch( {
+			path: addQueryArgs( '/wp/v2/users', {
+				include: missing,
+				per_page: 100,
+				context: 'edit',
+				_fields: 'id,name',
+			} ),
+		} )
+			.then( ( users ) => {
+				setLabelById( ( prev ) => {
+					const next = { ...prev };
+					users.forEach( ( user ) => {
+						next[ user.id ] = formatUserLabel( user.name, user.id );
+					} );
+					return next;
+				} );
+			} )
+			.catch( () => {} );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ values ] );
+
+	const search = useCallback( ( text ) => {
+		window.clearTimeout( debounceRef.current );
+
+		if ( ! text ) {
+			setSuggestions( [] );
+			return;
+		}
+
+		debounceRef.current = window.setTimeout( () => {
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/users', {
+					search: text,
+					per_page: 20,
+					context: 'edit',
+					_fields: 'id,name',
+				} ),
+			} )
+				.then( ( users ) => {
+					setLabelById( ( prev ) => {
+						const next = { ...prev };
+						users.forEach( ( user ) => {
+							next[ user.id ] = formatUserLabel(
+								user.name,
+								user.id
+							);
+						} );
+						return next;
+					} );
+					setSuggestions(
+						users.map( ( user ) =>
+							formatUserLabel( user.name, user.id )
+						)
+					);
+				} )
+				.catch( () => setSuggestions( [] ) );
+		}, 300 );
+	}, [] );
+
+	return (
+		<FormTokenField
+			label={ __( 'Users', 'wp-login-logout-redirect' ) }
+			value={ values.map(
+				( id ) => labelById[ id ] ?? formatUserLabel( '—', id )
+			) }
+			suggestions={ suggestions }
+			onInputChange={ search }
+			onChange={ ( tokens ) =>
+				onChange(
+					tokens
+						.map( ( token ) => parseUserId( token ) )
+						.filter( Boolean )
+				)
+			}
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+		/>
+	);
+};
+
+export default ConditionValueControl;

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -11,7 +11,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
 
 import { useSettings } from '../context/SettingsContext';
-import { RedirectIcon, Squares2X2Icon } from './icons';
+import { RedirectIcon, RulesIcon, Squares2X2Icon } from './icons';
 import SettingsHeader from './SettingsHeader';
 
 const TABS = [
@@ -20,9 +20,14 @@ const TABS = [
 		icon: RedirectIcon,
 		label: __( 'Redirects', 'wp-login-logout-redirect' ),
 	},
+	{
+		to: '/rules',
+		icon: RulesIcon,
+		label: __( 'Rules', 'wp-login-logout-redirect' ),
+	},
 ];
 
-const SKELETON_WIDTHS = [ 120 ];
+const SKELETON_WIDTHS = [ 120, 90 ];
 
 const Layout = () => {
 	const { isLoading } = useSettings();

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -44,9 +44,9 @@ const Layout = () => {
 	);
 
 	// Pro extensions add tabs / header actions via these filters.
-	const tabs = applyFilters( 'wplalr.tabs', TABS );
+	const tabs = applyFilters( 'wplalr_tabs', TABS );
 	const headerActions = applyFilters(
-		'wplalr.headerActions',
+		'wplalr_header_actions',
 		<>
 			<Button
 				variant="secondary"

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -9,6 +9,7 @@ import {
 import { Link, Outlet, useLocation } from 'react-router-dom';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
+import { applyFilters } from '@wordpress/hooks';
 
 import { useSettings } from '../context/SettingsContext';
 import { RedirectIcon, RulesIcon, Squares2X2Icon } from './icons';
@@ -42,6 +43,30 @@ const Layout = () => {
 		( notice ) => notice.type === 'snackbar'
 	);
 
+	// Pro extensions add tabs / header actions via these filters.
+	const tabs = applyFilters( 'wplalr.tabs', TABS );
+	const headerActions = applyFilters(
+		'wplalr.headerActions',
+		<>
+			<Button
+				variant="secondary"
+				href="https://wordpress.org/plugins/wp-login-and-logout-redirect/"
+				target="_blank"
+				rel="noreferrer"
+			>
+				{ __( 'Documentation', 'wp-login-logout-redirect' ) }
+			</Button>
+			<Button
+				variant="primary"
+				href="https://buymeacoffee.com/aiarnob"
+				target="_blank"
+				rel="noreferrer"
+			>
+				{ __( 'Support Me', 'wp-login-logout-redirect' ) }
+			</Button>
+		</>
+	);
+
 	return (
 		<div className="wplalr-admin-app">
 			<SettingsHeader
@@ -54,29 +79,7 @@ const Layout = () => {
 					'Configure where users are sent after they log in or log out.',
 					'wp-login-logout-redirect'
 				) }
-				actions={
-					<>
-						<Button
-							variant="secondary"
-							href="https://wordpress.org/plugins/wp-login-and-logout-redirect/"
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ __(
-								'Documentation',
-								'wp-login-logout-redirect'
-							) }
-						</Button>
-						<Button
-							variant="primary"
-							href="https://buymeacoffee.com/aiarnob"
-							target="_blank"
-							rel="noreferrer"
-						>
-							{ __( 'Support Me', 'wp-login-logout-redirect' ) }
-						</Button>
-					</>
-				}
+				actions={ headerActions }
 			/>
 
 			<main className="wplalr-main-content wplalr-setting-wrapper">
@@ -105,7 +108,7 @@ const Layout = () => {
 					) : (
 						<>
 							<div className="wplalr-hash-nav">
-								{ TABS.map( ( { to, icon: Icon, label } ) => (
+								{ tabs.map( ( { to, icon: Icon, label } ) => (
 									<Link
 										key={ to }
 										to={ to }

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -261,3 +261,106 @@
 .wplalr-admin-app .components-snackbar-list .components-snackbar {
 	margin-inline: auto !important;
 }
+
+/* ========== Rules: cards ========== */
+.wplalr-rule-card {
+	margin-bottom: 16px;
+}
+
+.wplalr-rule-header {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding-bottom: 16px;
+	margin-bottom: 16px;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.wplalr-rule-header .wplalr-rule-label {
+	flex: 1 1 auto;
+}
+
+.wplalr-rule-drag {
+	cursor: grab;
+	color: #646970;
+}
+
+.wplalr-rule-drag:active {
+	cursor: grabbing;
+}
+
+.wplalr-rule-drag svg {
+	width: 20px;
+	height: 20px;
+}
+
+/* ========== Rules: conditions ========== */
+.wplalr-rule-conditions {
+	margin-bottom: 16px;
+}
+
+.wplalr-rule-conditions-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: #1d2327;
+	margin: 0 0 12px 0;
+}
+
+.wplalr-rule-conditions-empty {
+	font-size: 13px;
+	color: #646970;
+	margin: 0 0 12px 0;
+	font-style: italic;
+}
+
+.wplalr-condition-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 12px;
+	margin-bottom: 12px;
+}
+
+.wplalr-condition-type {
+	flex: 0 0 160px;
+}
+
+.wplalr-condition-values {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.wplalr-condition-remove {
+	margin-top: 24px;
+	color: #d63638;
+}
+
+.wplalr-add-condition {
+	padding-left: 0;
+}
+
+/* ========== Rules: URLs ========== */
+.wplalr-rule-urls {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	padding-top: 16px;
+	border-top: 1px solid #f0f0f1;
+}
+
+/* ========== Rules: actions / empty ========== */
+.wplalr-rules-empty {
+	margin-bottom: 16px;
+}
+
+.wplalr-rules-empty p {
+	margin: 0;
+	color: #646970;
+	font-size: 14px;
+}
+
+.wplalr-rules-actions {
+	display: flex;
+	justify-content: space-between;
+	gap: 12px;
+	margin-top: 8px;
+}

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -347,6 +347,18 @@
 	border-top: 1px solid #f0f0f1;
 }
 
+/* ========== Placeholder hint ========== */
+.wplalr-placeholder-hint {
+	margin: 4px 0 0 0;
+	font-size: 12px;
+	color: #646970;
+	font-family: Menlo, Consolas, monaco, monospace;
+}
+
+.wplalr-settings-group + .wplalr-placeholder-hint {
+	margin-bottom: 16px;
+}
+
 /* ========== Rules: actions / empty ========== */
 .wplalr-rules-empty {
 	margin-bottom: 16px;

--- a/src/components/LayoutStyles.css
+++ b/src/components/LayoutStyles.css
@@ -334,6 +334,14 @@
 	color: #d63638;
 }
 
+/* Render the delete (trash) icons as outline glyphs in the danger color
+   instead of the solid fill @wordpress/components applies to button SVGs. */
+.wplalr-admin-app .wplalr-rule-delete svg,
+.wplalr-admin-app .wplalr-condition-remove svg {
+	fill: none;
+	stroke: currentColor;
+}
+
 .wplalr-add-condition {
 	padding-left: 0;
 }

--- a/src/components/RedirectSettings.js
+++ b/src/components/RedirectSettings.js
@@ -91,6 +91,12 @@ const RedirectSettings = () => {
 								__nextHasNoMarginBottom
 							/>
 						</div>
+						<p className="wplalr-placeholder-hint">
+							{ __(
+								'Placeholders: {{username}}, {{user_slug}}, {{website_url}}',
+								'wp-login-logout-redirect'
+							) }
+						</p>
 						<Button
 							variant="primary"
 							type="submit"

--- a/src/components/RedirectSettings.js
+++ b/src/components/RedirectSettings.js
@@ -41,13 +41,13 @@ const RedirectSettings = () => {
 					<CardBody className="wplalr-form-section-header">
 						<h3 className="wplalr-section-title">
 							{ __(
-								'Redirect URLs',
+								'Default Redirect URLs',
 								'wp-login-logout-redirect'
 							) }
 						</h3>
 						<p className="wplalr-section-description">
 							{ __(
-								'Set the URLs users are redirected to after logging in or out. Leave blank to use the WordPress defaults.',
+								'These default URLs are used when no rule on the Rules tab matches the user. Leave blank to use the WordPress defaults (admin for login, home for logout).',
 								'wp-login-logout-redirect'
 							) }
 						</p>

--- a/src/components/RuleCard.js
+++ b/src/components/RuleCard.js
@@ -1,0 +1,181 @@
+import { __ } from '@wordpress/i18n';
+import {
+	Card,
+	CardBody,
+	Button,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+import ConditionRow from './ConditionRow';
+import { emptyCondition } from '../utils';
+import { DragHandleIcon, PlusIcon, TrashIcon } from './icons';
+
+/**
+ * A single, sortable redirect rule card.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.rule     The rule object.
+ * @param {Function} props.onChange Receives a partial patch for the rule.
+ * @param {Function} props.onRemove Removes this rule.
+ */
+const RuleCard = ( { rule, onChange, onRemove } ) => {
+	const {
+		attributes,
+		listeners,
+		setNodeRef,
+		transform,
+		transition,
+		isDragging,
+	} = useSortable( { id: rule.id } );
+
+	const style = {
+		transform: CSS.Transform.toString( transform ),
+		transition,
+		opacity: isDragging ? 0.6 : 1,
+	};
+
+	const conditions = rule.conditions ?? [];
+
+	const updateCondition = ( index, patch ) => {
+		const next = conditions.map( ( condition, i ) =>
+			i === index ? { ...condition, ...patch } : condition
+		);
+		onChange( { conditions: next } );
+	};
+
+	const removeCondition = ( index ) => {
+		onChange( {
+			conditions: conditions.filter( ( _, i ) => i !== index ),
+		} );
+	};
+
+	const addCondition = () => {
+		onChange( { conditions: [ ...conditions, emptyCondition() ] } );
+	};
+
+	const homeUrl = window.wplalrAdmin?.homeUrl ?? '';
+
+	return (
+		<div ref={ setNodeRef } style={ style } className="wplalr-rule-card">
+			<Card>
+				<CardBody>
+					<div className="wplalr-rule-header">
+						<Button
+							className="wplalr-rule-drag"
+							icon={ <DragHandleIcon /> }
+							label={ __(
+								'Reorder rule',
+								'wp-login-logout-redirect'
+							) }
+							{ ...attributes }
+							{ ...listeners }
+						/>
+						<TextControl
+							className="wplalr-rule-label"
+							value={ rule.label ?? '' }
+							placeholder={ __(
+								'Rule name (optional)',
+								'wp-login-logout-redirect'
+							) }
+							onChange={ ( label ) => onChange( { label } ) }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<ToggleControl
+							label={ __(
+								'Enabled',
+								'wp-login-logout-redirect'
+							) }
+							checked={ !! rule.enabled }
+							onChange={ ( enabled ) => onChange( { enabled } ) }
+							__nextHasNoMarginBottom
+						/>
+						<Button
+							icon={ <TrashIcon /> }
+							label={ __(
+								'Delete rule',
+								'wp-login-logout-redirect'
+							) }
+							onClick={ onRemove }
+							isDestructive
+						/>
+					</div>
+
+					<div className="wplalr-rule-conditions">
+						<p className="wplalr-rule-conditions-title">
+							{ __(
+								'Apply when all of these match:',
+								'wp-login-logout-redirect'
+							) }
+						</p>
+						{ conditions.length === 0 && (
+							<p className="wplalr-rule-conditions-empty">
+								{ __(
+									'No conditions — this rule applies to everyone. Add a condition to target specific users.',
+									'wp-login-logout-redirect'
+								) }
+							</p>
+						) }
+						{ conditions.map( ( condition, index ) => (
+							<ConditionRow
+								key={ condition.id ?? index }
+								condition={ condition }
+								onChange={ ( patch ) =>
+									updateCondition( index, patch )
+								}
+								onRemove={ () => removeCondition( index ) }
+							/>
+						) ) }
+						<Button
+							className="wplalr-add-condition"
+							variant="link"
+							icon={ <PlusIcon /> }
+							onClick={ addCondition }
+						>
+							{ __(
+								'Add condition',
+								'wp-login-logout-redirect'
+							) }
+						</Button>
+					</div>
+
+					<div className="wplalr-rule-urls">
+						<TextControl
+							type="url"
+							label={ __(
+								'Login redirect URL',
+								'wp-login-logout-redirect'
+							) }
+							value={ rule.login_url ?? '' }
+							placeholder={ `${ homeUrl }/dashboard/` }
+							onChange={ ( value ) =>
+								onChange( { login_url: value } )
+							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						<TextControl
+							type="url"
+							label={ __(
+								'Logout redirect URL',
+								'wp-login-logout-redirect'
+							) }
+							value={ rule.logout_url ?? '' }
+							placeholder={ `${ homeUrl }/goodbye/` }
+							onChange={ ( value ) =>
+								onChange( { logout_url: value } )
+							}
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+					</div>
+				</CardBody>
+			</Card>
+		</div>
+	);
+};
+
+export default RuleCard;

--- a/src/components/RuleCard.js
+++ b/src/components/RuleCard.js
@@ -101,7 +101,6 @@ const RuleCard = ( { rule, onChange, onRemove } ) => {
 								'wp-login-logout-redirect'
 							) }
 							onClick={ onRemove }
-							isDestructive
 						/>
 					</div>
 

--- a/src/components/RuleCard.js
+++ b/src/components/RuleCard.js
@@ -95,12 +95,14 @@ const RuleCard = ( { rule, onChange, onRemove } ) => {
 							__nextHasNoMarginBottom
 						/>
 						<Button
+							className="wplalr-rule-delete"
 							icon={ <TrashIcon /> }
 							label={ __(
 								'Delete rule',
 								'wp-login-logout-redirect'
 							) }
 							onClick={ onRemove }
+							isDestructive
 						/>
 					</div>
 

--- a/src/components/RuleCard.js
+++ b/src/components/RuleCard.js
@@ -181,7 +181,7 @@ const RuleCard = ( { rule, onChange, onRemove } ) => {
 					</div>
 
 					{ /* Pro extensions inject extra rule fields here. */ }
-					{ applyFilters( 'wplalr.ruleFields', null, {
+					{ applyFilters( 'wplalr_rule_fields', null, {
 						rule,
 						onChange,
 					} ) }

--- a/src/components/RuleCard.js
+++ b/src/components/RuleCard.js
@@ -171,6 +171,12 @@ const RuleCard = ( { rule, onChange, onRemove } ) => {
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 						/>
+						<p className="wplalr-placeholder-hint">
+							{ __(
+								'Placeholders: {{username}}, {{user_slug}}, {{website_url}}',
+								'wp-login-logout-redirect'
+							) }
+						</p>
 					</div>
 				</CardBody>
 			</Card>

--- a/src/components/RuleCard.js
+++ b/src/components/RuleCard.js
@@ -6,6 +6,7 @@ import {
 	TextControl,
 	ToggleControl,
 } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 
@@ -178,6 +179,12 @@ const RuleCard = ( { rule, onChange, onRemove } ) => {
 							) }
 						</p>
 					</div>
+
+					{ /* Pro extensions inject extra rule fields here. */ }
+					{ applyFilters( 'wplalr.ruleFields', null, {
+						rule,
+						onChange,
+					} ) }
 				</CardBody>
 			</Card>
 		</div>

--- a/src/components/RulesSettings.js
+++ b/src/components/RulesSettings.js
@@ -1,0 +1,168 @@
+import { useState, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Button, Card, CardBody, Spinner } from '@wordpress/components';
+import {
+	DndContext,
+	closestCenter,
+	PointerSensor,
+	KeyboardSensor,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import {
+	SortableContext,
+	verticalListSortingStrategy,
+	sortableKeyboardCoordinates,
+	arrayMove,
+} from '@dnd-kit/sortable';
+
+import { useSettings } from '../context/SettingsContext';
+import RuleCard from './RuleCard';
+import { emptyRule, makeId } from '../utils';
+import { PlusIcon } from './icons';
+
+/**
+ * Ensure every rule and condition has a stable id for drag-and-drop / keys.
+ *
+ * @param {Array} rules Rules from the API.
+ * @return {Array} Rules with ids guaranteed.
+ */
+const withIds = ( rules ) =>
+	( rules ?? [] ).map( ( rule ) => ( {
+		...emptyRule(),
+		...rule,
+		id: rule.id || makeId(),
+		conditions: ( rule.conditions ?? [] ).map( ( condition ) => ( {
+			...condition,
+			id: condition.id || makeId(),
+		} ) ),
+	} ) );
+
+const RulesSettings = () => {
+	const { settings, isSaving, saveSettings } = useSettings();
+	const [ rules, setRules ] = useState( [] );
+
+	useEffect( () => {
+		setRules( withIds( settings.rules ) );
+	}, [ settings.rules ] );
+
+	const sensors = useSensors(
+		useSensor( PointerSensor, {
+			activationConstraint: { distance: 5 },
+		} ),
+		useSensor( KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		} )
+	);
+
+	const updateRule = ( id, patch ) => {
+		setRules( ( prev ) =>
+			prev.map( ( rule ) =>
+				rule.id === id ? { ...rule, ...patch } : rule
+			)
+		);
+	};
+
+	const removeRule = ( id ) => {
+		setRules( ( prev ) => prev.filter( ( rule ) => rule.id !== id ) );
+	};
+
+	const addRule = () => {
+		setRules( ( prev ) => [ ...prev, emptyRule() ] );
+	};
+
+	const handleDragEnd = ( event ) => {
+		const { active, over } = event;
+
+		if ( ! over || active.id === over.id ) {
+			return;
+		}
+
+		setRules( ( prev ) => {
+			const oldIndex = prev.findIndex( ( r ) => r.id === active.id );
+			const newIndex = prev.findIndex( ( r ) => r.id === over.id );
+			return arrayMove( prev, oldIndex, newIndex );
+		} );
+	};
+
+	const handleSave = () => {
+		saveSettings(
+			{ rules },
+			__( 'Redirect rules saved!', 'wp-login-logout-redirect' )
+		);
+	};
+
+	return (
+		<div className="wplalr-section" id="wplalr-rules-settings">
+			<Card className="wplalr-form-header-card">
+				<CardBody className="wplalr-form-section-header">
+					<h3 className="wplalr-section-title">
+						{ __( 'Redirect Rules', 'wp-login-logout-redirect' ) }
+					</h3>
+					<p className="wplalr-section-description">
+						{ __(
+							'Rules are evaluated top to bottom; the first matching rule wins. A rule matches when all of its conditions pass. When no rule matches, the defaults on the Redirects tab are used.',
+							'wp-login-logout-redirect'
+						) }
+					</p>
+				</CardBody>
+			</Card>
+
+			<DndContext
+				sensors={ sensors }
+				collisionDetection={ closestCenter }
+				onDragEnd={ handleDragEnd }
+			>
+				<SortableContext
+					items={ rules.map( ( rule ) => rule.id ) }
+					strategy={ verticalListSortingStrategy }
+				>
+					{ rules.map( ( rule ) => (
+						<RuleCard
+							key={ rule.id }
+							rule={ rule }
+							onChange={ ( patch ) =>
+								updateRule( rule.id, patch )
+							}
+							onRemove={ () => removeRule( rule.id ) }
+						/>
+					) ) }
+				</SortableContext>
+			</DndContext>
+
+			{ rules.length === 0 && (
+				<Card className="wplalr-rules-empty">
+					<CardBody>
+						<p>
+							{ __(
+								'No rules yet. Add a rule to redirect specific roles, users, or capabilities.',
+								'wp-login-logout-redirect'
+							) }
+						</p>
+					</CardBody>
+				</Card>
+			) }
+
+			<div className="wplalr-rules-actions">
+				<Button
+					variant="secondary"
+					icon={ <PlusIcon /> }
+					onClick={ addRule }
+				>
+					{ __( 'Add rule', 'wp-login-logout-redirect' ) }
+				</Button>
+				<Button
+					variant="primary"
+					onClick={ handleSave }
+					isBusy={ isSaving }
+					disabled={ isSaving }
+				>
+					{ isSaving && <Spinner /> }
+					{ __( 'Save Rules', 'wp-login-logout-redirect' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default RulesSettings;

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -6,4 +6,8 @@ export {
 	CheckBadgeIcon,
 	ExclamationCircleIcon,
 	Squares2X2Icon,
+	QueueListIcon as RulesIcon,
+	PlusIcon,
+	TrashIcon,
+	Bars2Icon as DragHandleIcon,
 } from '@heroicons/react/24/outline';

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-export { ArrowRightOnRectangleIcon as RedirectIcon } from '@heroicons/react/24/outline';
+export { ArrowsRightLeftIcon as RedirectIcon } from '@heroicons/react/24/outline';
 export {
 	CheckBadgeIcon,
 	ExclamationCircleIcon,
 	Squares2X2Icon,
-	QueueListIcon as RulesIcon,
+	AdjustmentsHorizontalIcon as RulesIcon,
 	PlusIcon,
 	TrashIcon,
 	Bars2Icon as DragHandleIcon,

--- a/src/components/icons.js
+++ b/src/components/icons.js
@@ -9,5 +9,5 @@ export {
 	AdjustmentsHorizontalIcon as RulesIcon,
 	PlusIcon,
 	TrashIcon,
-	Bars2Icon as DragHandleIcon,
+	ArrowsUpDownIcon as DragHandleIcon,
 } from '@heroicons/react/24/outline';

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,45 @@
+/**
+ * Generate a stable client-side id for a rule or condition.
+ *
+ * Used so drag-and-drop and React keys work before the server assigns a UUID.
+ *
+ * @return {string} A unique identifier.
+ */
+export const makeId = () => {
+	if (
+		typeof window !== 'undefined' &&
+		window.crypto &&
+		typeof window.crypto.randomUUID === 'function'
+	) {
+		return window.crypto.randomUUID();
+	}
+
+	return `wplalr-${ Date.now() }-${ Math.random()
+		.toString( 36 )
+		.slice( 2, 10 ) }`;
+};
+
+/**
+ * A fresh, empty condition.
+ *
+ * @return {Object} Condition object.
+ */
+export const emptyCondition = () => ( {
+	id: makeId(),
+	type: 'role',
+	values: [],
+} );
+
+/**
+ * A fresh, empty rule.
+ *
+ * @return {Object} Rule object.
+ */
+export const emptyRule = () => ( {
+	id: makeId(),
+	enabled: true,
+	label: '',
+	conditions: [],
+	login_url: '',
+	logout_url: '',
+} );


### PR DESCRIPTION
> ## 🧱 Stack level 2 of 4 — merge order #2
> This PR is part of a stacked chain. Merge **bottom-up** (closest to `develop` first):
> 1. #11 `feature/react-admin-settings` → `develop` *(merge first)*
> 2. #10 `feature/redirect-rule-engine` → `feature/react-admin-settings`
> 3. #9 `feature/admin-subpages` → `feature/redirect-rule-engine`
> 4. #8 `feature/audit-log-notifier` → `feature/admin-subpages` *(merge last)*
>
> **This PR: Level 2 — merge after #11** — check/merge after everything below it is merged.
## Summary

Adds a condition-based redirect rule engine on top of the React admin settings, plus the Rules UI and extensibility scaffolding.

- **Rule engine** (Phase 1) — role/user/capability conditions resolve login/logout destinations; free/pro roadmap.
- **React Rules UI** (Phase 2) — drag-and-drop rule ordering and condition editing.
- **Placeholders + hardening** (Phase 3) — `{{placeholder}}` tokens, redirect-loop and URL safety.
- **Pro extension scaffolding** (Phase 4) — filters/hooks for Pro to extend rules, match types, and the UI.
- Polish: underscore-convention hook names, admin menu/tab icons, browser-test-cases doc, and `{{placeholder}}` preservation on save.

## Commits
- Add redirect rule engine (Phase 1) + free/pro roadmap
- Add React Rules UI with drag-and-drop (Phase 2)
- Add placeholders and loop/URL hardening (Phase 3)
- Add Pro extension scaffolding (Phase 4)
- Rename extension hooks to underscore convention
- Add browser-test-cases doc for the admin UI
- Icon refinements (admin menu + tab + delete icons)
- Preserve {{placeholder}} tokens in redirect URLs on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)